### PR TITLE
Support Multiple DID Methods in HOAN

### DIFF
--- a/library/Fission/Models.hs
+++ b/library/Fission/Models.hs
@@ -44,7 +44,9 @@ HerokuAddOn
   deriving Show Eq
 
 User
-  did           DID           Maybe
+  didAlgorithm  DID.Algorithm Maybe
+  didPK         DID.PublicKey Maybe
+
   username      Username
   email         Email         Maybe
   role          Role

--- a/library/Fission/User/DID/Types.hs
+++ b/library/Fission/User/DID/Types.hs
@@ -1,4 +1,7 @@
-module Fission.User.DID.Types (DID (..)) where
+module Fission.User.DID.Types
+  ( PublicKey (..)
+  , Algorithm (..)
+  ) where
 
 import qualified RIO.Text as Text
 
@@ -7,7 +10,20 @@ import           Database.Persist.Postgresql
 
 import           Fission.Prelude
 
-newtype DID = DID { unDID :: Text }
+data Algorithm
+  = EdDSA
+  | ECDSA
+  | SECP
+  | RSA_4096
+  deriving ( Eq
+           , Generic
+           , Show
+           , ToJSON
+           , FromJSON
+           , ToSchema
+           )
+
+newtype PublicKey = PublicKey { unPublicKey :: Text }
   deriving          ( Eq
                     , Generic
                     , Show
@@ -17,11 +33,11 @@ newtype DID = DID { unDID :: Text }
                     , ToSchema
                     )
 
-instance PersistField DID where
-  toPersistValue (DID pk) = PersistText pk
+instance PersistField PublicKey where
+  toPersistValue (PublicKey pk) = PersistText pk
   fromPersistValue = \case
-    PersistText pk -> Right (DID pk)
-    other          -> Left ("Invalid Persistent DID: " <> Text.pack (show other))
+    PersistText pk -> Right (PublicKey pk)
+    other          -> Left ("Invalid Persistent PublicKey: " <> Text.pack (show other))
 
-instance PersistFieldSql DID where
+instance PersistFieldSql PublicKey where
   sqlType _pxy = SqlString


### PR DESCRIPTION
Since the WebCrypto API doesn't officially include EdDSA (yet?), Chrome has support for it but FF does not 😭 Since this is all user-controlled AuthN, we should probably support multiple methods. We already have Higher Order AuthN (HOAN), so this should not be prohibitive to implement in the near term.

* [x] Figure out which we will support first
  * ECDSA
  * ~~SECP~~
  * ~~P-256 / P-512~~
  * RSA (2048/~~4096~~)
* [ ] Implement in DB