### PR TITLE
Report correct auth status code

### DIFF
--- a/library/Fission/App/Domain/Error.hs
+++ b/library/Fission/App/Domain/Error.hs
@@ -10,7 +10,6 @@ import           Fission.Models
 import           Fission.URL
 
 import           Fission.Web.Error.Class
-import qualified Fission.Internal.UTF8 as UTF8
 
 data NotRegisteredToApp
   = NotRegisteredToApp AppId DomainName (Maybe Subdomain)
@@ -28,7 +27,7 @@ data AlreadyAssociated = AlreadyAssociated
 
 instance ToServerError AlreadyAssociated where
   toServerError (AlreadyAssociated _ (DomainName domainName) maySubdomain) =
-    err409 { errBody = "An app already exists at " <> UTF8.textToLazyBS url }
+    err409 { errBody = "An app already exists at " <> displayLazyBS url }
     where
       url = case maySubdomain of
         Nothing              -> domainName

--- a/library/Fission/Error/AlreadyExists/Types.hs
+++ b/library/Fission/Error/AlreadyExists/Types.hs
@@ -5,10 +5,8 @@ module Fission.Error.AlreadyExists.Types (AlreadyExists (..)) where
 import           Servant
 
 import           Fission.Prelude
-import           Fission.Web.Error.Class
+import           Fission.Web.Error as Error
 import           Fission.Models
-
-import qualified Fission.Internal.UTF8 as UTF8
 
 data AlreadyExists entity
   = AlreadyExists
@@ -18,7 +16,7 @@ data AlreadyExists entity
            )
 
 instance Display (AlreadyExists entity) => ToServerError (AlreadyExists entity) where
-  toServerError _ = err409 { errBody = UTF8.showLazyBS <| textDisplay (AlreadyExists @entity) }
+  toServerError alreadyExists = Error.withMessage alreadyExists err409
 
 instance Display (AlreadyExists User) where
   display _ = "User already exists"

--- a/library/Fission/Error/NotFound/Types.hs
+++ b/library/Fission/Error/NotFound/Types.hs
@@ -27,3 +27,6 @@ instance Display (NotFound Domain) where
 
 instance Display (NotFound App) where
   display _ = "App not found"
+
+instance Display (NotFound AppDomain) where
+  display _ = "App/Domain relation not found"

--- a/library/Fission/Internal/UTF8.hs
+++ b/library/Fission/Internal/UTF8.hs
@@ -3,7 +3,6 @@ module Fission.Internal.UTF8
   ( Textable (..)
   , putText
   , putTextLn
-  -- , showLazyBS
   , displayLazyBS
   , toBase58Text
   , fromRawBytes
@@ -53,15 +52,9 @@ instance Textable ByteString where
 instance Textable Lazy.ByteString where
   encode = encode . Lazy.toStrict
 
--- showLazyBS :: Show a => a -> Lazy.ByteString
--- showLazyBS = textToLazyBS . textDisplay . displayShow
-
 displayLazyBS :: Display a => a -> Lazy.ByteString
 displayLazyBS = Lazy.fromStrict . encodeUtf8 . textDisplay
 
--- textToLazyBS :: Text -> Lazy.ByteString
--- textToLazyBS = Lazy.fromStrict . Text.encodeUtf8
- 
 fromRawBytes :: [Word8] -> Text
 fromRawBytes = decodeUtf8Lenient . Strict.pack
 

--- a/library/Fission/Internal/UTF8.hs
+++ b/library/Fission/Internal/UTF8.hs
@@ -3,7 +3,7 @@ module Fission.Internal.UTF8
   ( Textable (..)
   , putText
   , putTextLn
-  , showLazyBS
+  -- , showLazyBS
   , displayLazyBS
   , toBase58Text
   , fromRawBytes
@@ -20,7 +20,7 @@ module Fission.Internal.UTF8
   , stripN
   , stripNBS
   , stripNewline
-  , textToLazyBS
+  -- , textToLazyBS
   , textShow
   , wrapIn
   , wrapInBS
@@ -53,14 +53,14 @@ instance Textable ByteString where
 instance Textable Lazy.ByteString where
   encode = encode . Lazy.toStrict
 
-showLazyBS :: Show a => a -> Lazy.ByteString
-showLazyBS = textToLazyBS . textDisplay . displayShow
+-- showLazyBS :: Show a => a -> Lazy.ByteString
+-- showLazyBS = textToLazyBS . textDisplay . displayShow
 
 displayLazyBS :: Display a => a -> Lazy.ByteString
 displayLazyBS = Lazy.fromStrict . encodeUtf8 . textDisplay
 
-textToLazyBS :: Text -> Lazy.ByteString
-textToLazyBS = Lazy.fromStrict . Text.encodeUtf8
+-- textToLazyBS :: Text -> Lazy.ByteString
+-- textToLazyBS = Lazy.fromStrict . Text.encodeUtf8
  
 fromRawBytes :: [Word8] -> Text
 fromRawBytes = decodeUtf8Lenient . Strict.pack

--- a/library/Fission/Internal/UTF8.hs
+++ b/library/Fission/Internal/UTF8.hs
@@ -19,7 +19,6 @@ module Fission.Internal.UTF8
   , stripN
   , stripNBS
   , stripNewline
-  -- , textToLazyBS
   , textShow
   , wrapIn
   , wrapInBS

--- a/library/Fission/Types.hs
+++ b/library/Fission/Types.hs
@@ -40,8 +40,9 @@ import qualified Fission.URL as URL
 
 import           Fission.Platform.Heroku.Types as Heroku
 
-import           Fission.Web.Auth     as Auth
-import qualified Fission.Web.Auth.DID as Auth.DID
+import           Fission.Web.Auth       as Auth
+import qualified Fission.Web.Auth.DID   as Auth.DID
+import qualified Fission.Web.Auth.Token as Auth.Token
 
 import           Fission.Web.Server.Reflective as Reflective
 import           Fission.Web.Handler
@@ -51,7 +52,6 @@ import           Fission.User.DID.Types
 import           Fission.Web.Auth.Token.Basic.Class
 import           Fission.Web.Auth.Token.JWT.Resolver as JWT
  
-import           Fission.Web.Auth.UCAN as Auth.UCAN
 import           Fission.Authorization.ServerDID.Class
 
 import           Fission.App.Content as App.Content
@@ -69,9 +69,6 @@ newtype Fission a = Fission { unFission :: RIO Config a }
                    , MonadCatch
                    , MonadMask
                    )
-
--- FIXME think about if you just want the ToServerError stuff on an
--- MonadThrow Fission instance
 
 instance MonadLogger Fission where
   monadLoggerLog loc src lvl msg = Fission $ monadLoggerLog loc src lvl msg
@@ -217,7 +214,7 @@ instance MonadAuth Authorization Fission where
   getVerifier = do
     cfg <- ask
     return $ mkAuthHandler \req ->
-      toHandler (runRIO cfg) . unFission $ Auth.UCAN.handler req
+      toHandler (runRIO cfg) . unFission $ Auth.Token.handler req
 
 instance App.Domain.Initializer Fission where
   initial = asks baseAppDomainName

--- a/library/Fission/Types.hs
+++ b/library/Fission/Types.hs
@@ -70,6 +70,9 @@ newtype Fission a = Fission { unFission :: RIO Config a }
                    , MonadMask
                    )
 
+-- FIXME think about if you just want the ToServerError stuff on an
+-- MonadThrow Fission instance
+
 instance MonadLogger Fission where
   monadLoggerLog loc src lvl msg = Fission $ monadLoggerLog loc src lvl msg
 

--- a/library/Fission/URL/DomainName/Types.hs
+++ b/library/Fission/URL/DomainName/Types.hs
@@ -9,7 +9,6 @@ import           Data.Swagger                hiding (get)
 import           Servant
 
 import           Fission.Prelude
-import qualified Fission.Internal.UTF8 as UTF8
 
 -- | Type safety wrapper for domain names
 newtype DomainName = DomainName { get :: Text }
@@ -59,10 +58,10 @@ instance FromJSON DomainName where
     DomainName <$> parseJSON (String txt)
 
 instance MimeRender PlainText DomainName where
-  mimeRender _ = UTF8.textToLazyBS . get
+  mimeRender _ = displayLazyBS . get
 
 instance MimeRender OctetStream DomainName where
-  mimeRender _ = UTF8.textToLazyBS . get
+  mimeRender _ = displayLazyBS . get
 
 instance MimeUnrender PlainText DomainName where
   mimeUnrender _proxy bs =

--- a/library/Fission/URL/Subdomain/Types.hs
+++ b/library/Fission/URL/Subdomain/Types.hs
@@ -53,10 +53,10 @@ instance FromJSON Subdomain where
     Subdomain <$> parseJSON (String txt)
 
 instance MimeRender PlainText Subdomain where
-  mimeRender _ = UTF8.textToLazyBS . get
+  mimeRender _ = displayLazyBS . get
 
 instance MimeRender OctetStream Subdomain where
-  mimeRender _ = UTF8.textToLazyBS . get
+  mimeRender _ = displayLazyBS . get
 
 instance MimeUnrender PlainText Subdomain where
   mimeUnrender _proxy bs =
@@ -76,7 +76,7 @@ instance Arbitrary Subdomain where
       else do
         adjectives <- sequence (elements <$> take 3 generators)
         noun       <- elements nouns
-        return . Subdomain <| Text.intercalate "-" <| adjectives <> [noun]
+        return . Subdomain . Text.intercalate "-" $ adjectives <> [noun]
 
 opinions :: [Text]
 opinions =

--- a/library/Fission/User/Creator/Error.hs
+++ b/library/Fission/User/Creator/Error.hs
@@ -4,7 +4,6 @@ import           Servant.Server
 
 import           Fission.Prelude
 import           Fission.Web.Error
-import qualified Fission.Internal.UTF8 as UTF8
 
 data AlreadyExists = AlreadyExists
   deriving ( Show
@@ -17,4 +16,4 @@ instance Display AlreadyExists where
 
 instance ToServerError AlreadyExists where
   toServerError AlreadyExists =
-    err409 { errBody = UTF8.showLazyBS <| textDisplay AlreadyExists }
+    err409 { errBody = displayLazyBS AlreadyExists }

--- a/library/Fission/User/Password/Error.hs
+++ b/library/Fission/User/Password/Error.hs
@@ -4,7 +4,6 @@ import           Servant.Server
 
 import           Fission.Prelude
 import           Fission.Web.Error
-import qualified Fission.Internal.UTF8 as UTF8
 
 data FailedDigest = FailedDigest
   deriving ( Show
@@ -13,8 +12,8 @@ data FailedDigest = FailedDigest
            )
 
 instance Display FailedDigest where
-  display FailedDigest  = "Could not create password digest"
+  display FailedDigest = "Could not create password digest"
 
 instance ToServerError FailedDigest where
   toServerError FailedDigest =
-    err500 { errBody = UTF8.showLazyBS $ textDisplay FailedDigest }
+    err500 { errBody = displayLazyBS FailedDigest }

--- a/library/Fission/User/Password/Error.hs
+++ b/library/Fission/User/Password/Error.hs
@@ -17,4 +17,4 @@ instance Display FailedDigest where
 
 instance ToServerError FailedDigest where
   toServerError FailedDigest =
-    err500 { errBody = UTF8.showLazyBS <| textDisplay FailedDigest }
+    err500 { errBody = UTF8.showLazyBS $ textDisplay FailedDigest }

--- a/library/Fission/User/Username/Error.hs
+++ b/library/Fission/User/Username/Error.hs
@@ -6,7 +6,6 @@ import           Servant.Server
 
 import           Fission.Prelude
 import           Fission.Web.Error
-import qualified Fission.Internal.UTF8 as UTF8
 
 data Invalid = Invalid
   deriving ( Show
@@ -19,4 +18,4 @@ instance Display Invalid where
 
 instance ToServerError Invalid where
   toServerError Invalid =
-    err422 { errBody = UTF8.showLazyBS <| textDisplay Invalid }
+    err422 { errBody = displayLazyBS Invalid }

--- a/library/Fission/Web/App/Create.hs
+++ b/library/Fission/Web/App/Create.hs
@@ -35,11 +35,6 @@ create ::
   => Authorization
   -> ServerT API m
 create Authorization {about = Entity userId _} = do
-  defaultDomain <- App.Domain.initial
-
-  userId
-    |> App.createWithPlaceholder
-    |> runDBNow
-    |> bind \case
-      Right (_, subdomain) -> return (subdomain, defaultDomain)
-      Left err             -> Web.Error.throw err
+  (_, subdomain) <- Web.Error.ensure =<< runDBNow (App.createWithPlaceholder userId)
+  defaultDomain  <- App.Domain.initial
+  return (subdomain, defaultDomain)

--- a/library/Fission/Web/App/Create.hs
+++ b/library/Fission/Web/App/Create.hs
@@ -9,7 +9,7 @@ import           Servant
 import           Fission.Prelude
 
 import           Fission.Authorization
-import           Fission.Web.Error
+import           Fission.Web.Error as Web.Error
 import           Fission.URL
 
 import qualified Fission.App.Creator as App
@@ -26,6 +26,7 @@ type API
 create ::
   ( App.Domain.Initializer    m
   , MonadTime                 m
+  , MonadLogger               m
   , MonadDNSLink              m
   , MonadDB                 t m
   , App.Creator             t
@@ -41,4 +42,4 @@ create Authorization {about = Entity userId _} = do
     |> runDBNow
     |> bind \case
       Right (_, subdomain) -> return (subdomain, defaultDomain)
-      Left err             -> throwM <| toServerError err
+      Left err             -> Web.Error.throw err

--- a/library/Fission/Web/Auth.hs
+++ b/library/Fission/Web/Auth.hs
@@ -43,11 +43,11 @@ mkAuth ::
   )
   => m (Context Checks)
 mkAuth = do
-  didAuth    <- Auth.getVerifier
-  ucanAuth   <- Auth.getVerifier
+  didAuth         <- Auth.getVerifier
+  higherOrderAuth <- Auth.getVerifier
   herokuAuth <- BasicAuth.getVerifier
   return $ didAuth
-        :. ucanAuth
+        :. higherOrderAuth
         :. herokuAuth
         :. EmptyContext
 

--- a/library/Fission/Web/Auth/DID.hs
+++ b/library/Fission/Web/Auth/DID.hs
@@ -35,6 +35,8 @@ handler req =
           logWarn $ "Failed registration with token " <> encode token
           throwM err
 
+  -- FIXME chekc that this is all right
+
         Right JWT.JWT {claims = JWT.Claims {sender}} ->
           return sender
 

--- a/library/Fission/Web/Auth/DID.hs
+++ b/library/Fission/Web/Auth/DID.hs
@@ -3,6 +3,8 @@ module Fission.Web.Auth.DID (handler) where
 import           Network.Wai
 
 import           Fission.Prelude
+ 
+import qualified Fission.Web.Error as Web.Error
 
 import qualified Fission.Web.Auth.Token as Token
 import qualified Fission.Web.Auth.Error as Auth
@@ -33,9 +35,7 @@ handler req =
       JWT.check rawContent jwt >>= \case
         Left err -> do
           logWarn $ "Failed registration with token " <> encode token
-          throwM err
-
-  -- FIXME chekc that this is all right
+          Web.Error.throw err
 
         Right JWT.JWT {claims = JWT.Claims {sender}} ->
           return sender

--- a/library/Fission/Web/Auth/DID.hs
+++ b/library/Fission/Web/Auth/DID.hs
@@ -19,7 +19,7 @@ import           Fission.User.DID.Types
 import           Fission.Authorization.ServerDID
 
 -- | Auth handler for registering DIDs
--- Ensures properly formatted token but does not check against DB
+-- Ensures properly formatted token but *does not check against DB*
 handler ::
   ( JWT.Resolver m
   , ServerDID    m

--- a/library/Fission/Web/Auth/Error.hs
+++ b/library/Fission/Web/Auth/Error.hs
@@ -12,8 +12,6 @@ data Error
   | Unauthorized
   deriving ( Exception
            , Eq
-           -- , Generic
-           -- , ToJSON
            , Show
            )
 

--- a/library/Fission/Web/Auth/Error.hs
+++ b/library/Fission/Web/Auth/Error.hs
@@ -1,6 +1,9 @@
 module Fission.Web.Auth.Error (Error (..)) where
 
-import Fission.Prelude
+import qualified Servant.Server as Server
+
+import           Fission.Prelude
+import           Fission.Web.Error as Error
 
 data Error
   = NoToken
@@ -9,8 +12,8 @@ data Error
   | Unauthorized
   deriving ( Exception
            , Eq
-           , Generic
-           , ToJSON
+           -- , Generic
+           -- , ToJSON
            , Show
            )
 
@@ -20,3 +23,6 @@ instance Display Error where
     BadToken     -> "Token is improperly formatted"
     NoSuchUser   -> "No such user exists"
     Unauthorized -> "User not authorized"
+
+instance ToServerError Error where
+  toServerError err = Error.withMessage err Server.err401

--- a/library/Fission/Web/Auth/Token.hs
+++ b/library/Fission/Web/Auth/Token.hs
@@ -18,6 +18,8 @@ import qualified Fission.Web.Auth.Token.Bearer as Bearer
 import           Fission.Web.Auth.Token.Types
 import qualified Fission.Web.Auth.Token.JWT.Resolver as JWT
 
+-- FIXME do we actually use this still?
+
 -- | Higher order auth handler
 --   Uses basic auth for "Basic " tokens
 --   Uses our custom jwt auth for "Bearer " tokens

--- a/library/Fission/Web/Auth/Token.hs
+++ b/library/Fission/Web/Auth/Token.hs
@@ -11,18 +11,16 @@ import           Fission.Prelude
 import           Fission.Authorization
 import qualified Fission.User as User
 
-import qualified Fission.Web.Auth.Error        as Auth
-import qualified Fission.Web.Auth.Token.Basic  as Basic
-import qualified Fission.Web.Auth.Token.Bearer as Bearer
+import qualified Fission.Web.Auth.Error       as Auth
+import qualified Fission.Web.Auth.Token.Basic as Basic
+import qualified Fission.Web.Auth.Token.UCAN  as UCAN
 
 import           Fission.Web.Auth.Token.Types
 import qualified Fission.Web.Auth.Token.JWT.Resolver as JWT
 
--- FIXME do we actually use this still?
-
 -- | Higher order auth handler
---   Uses basic auth for "Basic " tokens
---   Uses our custom jwt auth for "Bearer " tokens
+--   Uses basic auth for "Basic" tokens
+--   Uses our custom JWT auth for "Bearer" tokens
 handler ::
   ( JWT.Resolver     m
   , ServerDID        m
@@ -30,16 +28,15 @@ handler ::
   , MonadThrow       m
   , MonadTime        m
   , MonadDB        t m
-  , MonadThrow     t
   , User.Retriever t
   )
   => Request
   -> m Authorization
 handler req =
   case get req of
-    Just (Bearer bearer) -> Bearer.handler bearer
+    Just (Bearer bearer) -> UCAN.handler bearer
     Just (Basic  basic') -> Basic.handler basic'
-    Nothing                   -> throwM Auth.NoToken
+    Nothing              -> throwM Auth.NoToken
 
 get :: Request -> Maybe Token
 get req = do

--- a/library/Fission/Web/Auth/Token/Bearer.hs
+++ b/library/Fission/Web/Auth/Token/Bearer.hs
@@ -12,7 +12,7 @@ import           Servant.Server
 
 import           Fission.Prelude
 
-import qualified Fission.Web.Error as Error
+import qualified Fission.Web.Error as Web.Err
 import           Fission.Error.NotFound.Types
 
 import           Fission.Authorization
@@ -39,6 +39,7 @@ handler ::
   , ServerDID        m
   , MonadLogger      m
   , MonadThrow       m
+  , MonadLogger      m
   , MonadDB        t m
   , MonadThrow     t
   , User.Retriever t
@@ -52,9 +53,9 @@ handler token@(Auth.Bearer.Token jwt (Just rawContent)) =
       Web.Err.throw err
 
     Right JWT {claims = Claims {..}} -> do
-      runDB $ User.getByPublicKey (DID.publicKey sender) >>= \case
+      runDB (User.getByPublicKey $ DID.publicKey sender) >>= \case
         Nothing ->
-          Web.Err.throw $ NotFound @User FIXME
+          Web.Err.throw $ NotFound @User
 
         Just about ->
           return Authorization {sender = Right sender, ..}

--- a/library/Fission/Web/Auth/Token/Bearer.hs
+++ b/library/Fission/Web/Auth/Token/Bearer.hs
@@ -60,4 +60,4 @@ handler token@(Auth.Bearer.Token jwt (Just rawContent)) =
           return Authorization {sender = Right sender, ..}
 
 handler _ = -- should be impossible
-  throwM $ err500 { errBody = "Unable to parse JWT" }
+  throwM $ err401 { errBody = "Unable to parse JWT" }

--- a/library/Fission/Web/Auth/Token/Bearer.hs
+++ b/library/Fission/Web/Auth/Token/Bearer.hs
@@ -12,7 +12,7 @@ import           Servant.Server
 
 import           Fission.Prelude
 
-import           Fission.Web.Error.Class
+import qualified Fission.Web.Error as Error
 import           Fission.Error.NotFound.Types
 
 import           Fission.Authorization
@@ -49,13 +49,12 @@ handler token@(Auth.Bearer.Token jwt (Just rawContent)) =
   check rawContent jwt >>= \case
     Left err -> do
       logWarn $ "===> Failed login with token !! " <> encode token
-      throwM err402 -- FIXME
-      -- throwM err
+      Web.Err.throw err
 
     Right JWT {claims = Claims {..}} -> do
       runDB $ User.getByPublicKey (DID.publicKey sender) >>= \case
         Nothing ->
-          throwM err403 -- . toServerError $ NotFound @User FIXME
+          Web.Err.throw $ NotFound @User FIXME
 
         Just about ->
           return Authorization {sender = Right sender, ..}

--- a/library/Fission/Web/Auth/Token/Bearer.hs
+++ b/library/Fission/Web/Auth/Token/Bearer.hs
@@ -48,13 +48,14 @@ handler ::
 handler token@(Auth.Bearer.Token jwt (Just rawContent)) =
   check rawContent jwt >>= \case
     Left err -> do
-      logWarn $ "Failed login with token " <> encode token
-      throwM err
+      logWarn $ "===> Failed login with token !! " <> encode token
+      throwM err402 -- FIXME
+      -- throwM err
 
     Right JWT {claims = Claims {..}} -> do
       runDB $ User.getByPublicKey (DID.publicKey sender) >>= \case
         Nothing ->
-          throwM . toServerError $ NotFound @User
+          throwM err403 -- . toServerError $ NotFound @User FIXME
 
         Just about ->
           return Authorization {sender = Right sender, ..}

--- a/library/Fission/Web/Auth/Token/Bearer.hs
+++ b/library/Fission/Web/Auth/Token/Bearer.hs
@@ -1,67 +1,11 @@
 module Fission.Web.Auth.Token.Bearer
-  ( -- handler
-
-  -- * Reexport
- 
-   module Fission.Web.Auth.Token.JWT
+  ( module Fission.Web.Auth.Token.JWT
   , module Fission.Web.Auth.Token.JWT.Error
   , module Fission.Web.Auth.Token.JWT.Validation
   ) where
-
-import           Servant.Server
-
-import           Fission.Prelude
-
-import qualified Fission.Web.Error as Web.Err
-import           Fission.Error.NotFound.Types
-
-import           Fission.Authorization
-
-import           Fission.Models
-import qualified Fission.User     as User
-import qualified Fission.User.DID as DID
- 
-import qualified Fission.Web.Auth.Token.Bearer.Types as Auth.Bearer
-
-import           Fission.Web.Auth.Token.JWT          as JWT
-import           Fission.Web.Auth.Token.JWT.Error    as JWT
-import qualified Fission.Web.Auth.Token.JWT.Resolver as JWT
 
 -- Reexport
 
 import           Fission.Web.Auth.Token.JWT
 import           Fission.Web.Auth.Token.JWT.Error
 import           Fission.Web.Auth.Token.JWT.Validation
-
--- -- | Auth handler for non-delegated auth.
--- -- Ensures properly formatted token
--- -- e.g. A new user account
--- -- Existing users should be validated against the 'UCAN' handler
--- handler ::
---   ( MonadTime        m
---   , JWT.Resolver     m
---   , ServerDID        m
---   , MonadLogger      m
---   , MonadThrow       m
---   , MonadDB        t m
---   , User.Retriever t
---   )
---   => Auth.Bearer.Token
---   -> m Authorization
--- handler Auth.Bearer.Token {..} =
---   case rawContent of
---     Nothing ->
---       Web.Err.throw err401 { errBody = "Unable to parse JWT" }
-
---     Just encoded ->
---       check encoded jwt >>= \case
---         Left err ->
---           Web.Err.throw err
-
---         Right JWT {claims = Claims {..}} ->
---           runDB (User.getByPublicKey $ DID.publicKey sender) >>= \case
---             Nothing ->
---               Web.Err.throw $ NotFound @User
-
---             Just about ->
---               return Authorization {sender = Right sender, ..}

--- a/library/Fission/Web/Auth/Token/Bearer.hs
+++ b/library/Fission/Web/Auth/Token/Bearer.hs
@@ -1,9 +1,9 @@
 module Fission.Web.Auth.Token.Bearer
-  ( handler
+  ( -- handler
 
   -- * Reexport
  
-  , module Fission.Web.Auth.Token.JWT
+   module Fission.Web.Auth.Token.JWT
   , module Fission.Web.Auth.Token.JWT.Error
   , module Fission.Web.Auth.Token.JWT.Validation
   ) where
@@ -33,36 +33,35 @@ import           Fission.Web.Auth.Token.JWT
 import           Fission.Web.Auth.Token.JWT.Error
 import           Fission.Web.Auth.Token.JWT.Validation
 
--- | Auth handler for delegated auth
--- Ensures properly formatted token *and does NOT check against DB*
--- e.g. A new user account
--- Existing users should be validated against the 'UCAN' handler
-handler ::
-  ( MonadTime        m
-  , JWT.Resolver     m
-  , ServerDID        m
-  , MonadLogger      m
-  , MonadThrow       m
-  , MonadDB        t m
-  , User.Retriever t
-  )
-  => Auth.Bearer.Token
-  -> m Authorization
-handler Auth.Bearer.Token {..} =
-  case rawContent of
-    Nothing ->
-      throwM $ err401 { errBody = "Unable to parse JWT" }
+-- -- | Auth handler for non-delegated auth.
+-- -- Ensures properly formatted token
+-- -- e.g. A new user account
+-- -- Existing users should be validated against the 'UCAN' handler
+-- handler ::
+--   ( MonadTime        m
+--   , JWT.Resolver     m
+--   , ServerDID        m
+--   , MonadLogger      m
+--   , MonadThrow       m
+--   , MonadDB        t m
+--   , User.Retriever t
+--   )
+--   => Auth.Bearer.Token
+--   -> m Authorization
+-- handler Auth.Bearer.Token {..} =
+--   case rawContent of
+--     Nothing ->
+--       Web.Err.throw err401 { errBody = "Unable to parse JWT" }
 
-    Just encoded ->
-      check encoded jwt >>= \case
-        Left err ->
-          Web.Err.throw err
+--     Just encoded ->
+--       check encoded jwt >>= \case
+--         Left err ->
+--           Web.Err.throw err
 
-        Right JWT {claims = Claims {..}} -> do
-          -- Need to get down to the innermost JWT
-          runDB (User.getByPublicKey $ DID.publicKey sender) >>= \case
-            Nothing ->
-              Web.Err.throw $ NotFound @User
+--         Right JWT {claims = Claims {..}} ->
+--           runDB (User.getByPublicKey $ DID.publicKey sender) >>= \case
+--             Nothing ->
+--               Web.Err.throw $ NotFound @User
 
-            Just about ->
-              return Authorization {sender = Right sender, ..}
+--             Just about ->
+--               return Authorization {sender = Right sender, ..}

--- a/library/Fission/Web/Auth/Token/Bearer.hs
+++ b/library/Fission/Web/Auth/Token/Bearer.hs
@@ -33,6 +33,10 @@ import           Fission.Web.Auth.Token.JWT
 import           Fission.Web.Auth.Token.JWT.Error
 import           Fission.Web.Auth.Token.JWT.Validation
 
+-- | Auth handler for delegated auth
+-- Ensures properly formatted token *and does NOT check against DB*
+-- e.g. A new user account
+-- Existing users should be validated against the 'UCAN' handler
 handler ::
   ( MonadTime        m
   , JWT.Resolver     m
@@ -55,6 +59,7 @@ handler Auth.Bearer.Token {..} =
           Web.Err.throw err
 
         Right JWT {claims = Claims {..}} -> do
+          -- Need to get down to the innermost JWT
           runDB (User.getByPublicKey $ DID.publicKey sender) >>= \case
             Nothing ->
               Web.Err.throw $ NotFound @User

--- a/library/Fission/Web/Auth/Token/JWT/Claims/Error.hs
+++ b/library/Fission/Web/Auth/Token/JWT/Claims/Error.hs
@@ -24,10 +24,5 @@ instance Display Error where
 instance ToServerError Error where
   toServerError = \case
     ProofError    err -> toServerError err
-    IncorrectReceiver -> err422 { errBody = displayLazyBS IncorrectReceiver }
-    Expired           -> err410 { errBody = displayLazyBS Expired }
-    TooEarly          -> ServerError { errHTTPCode     = 425
-                                     , errReasonPhrase = show TooEarly
-                                     , errBody         = ""
-                                     , errHeaders      = []
-                                     }
+    IncorrectReceiver -> err401 { errBody = displayLazyBS IncorrectReceiver }
+    Expired           -> err401 { errBody = displayLazyBS Expired }

--- a/library/Fission/Web/Auth/Token/UCAN.hs
+++ b/library/Fission/Web/Auth/Token/UCAN.hs
@@ -3,7 +3,6 @@ module Fission.Web.Auth.Token.UCAN (handler) where
 import           Fission.Prelude
 import           Fission.Models
 
-import           Fission.Web.Error.Class
 import           Fission.Error.NotFound.Types
 
 import qualified Fission.User.Retriever as User
@@ -22,8 +21,8 @@ import           Fission.Authorization.Types
 import           Fission.Authorization.ServerDID
 import           Fission.User.DID.Types
 
--- -- | Auth handler for delegated auth
--- -- Ensures properly formatted token *and does check against DB*
+-- | Auth handler for delegated auth
+-- Ensures properly formatted token *and does check against DB*
 handler ::
   ( MonadLogger m
   , MonadThrow m
@@ -39,7 +38,7 @@ handler (Bearer.Token jwt (Just rawContent)) = do
   void . Web.Error.ensureM =<< JWT.check rawContent jwt
   toAuthorization jwt
 
-handler _ = do -- Should be impossible
+handler _ = do -- Practically impossible
   logError @Text "Have a token without raw content... somehow"
   Web.Error.throw Auth.NoToken
 
@@ -56,7 +55,7 @@ toAuthorization jwt@JWT {claims = JWT.Claims {..}} = do
   JWT {claims = JWT.Claims {sender = DID {publicKey = pk}}} <- getRoot jwt
   runDB (User.getByPublicKey pk) >>= \case
     Just about -> return Authorization {sender = Right sender, ..}
-    Nothing    -> throwM . toServerError $ NotFound @User
+    Nothing    -> Web.Error.throw $ NotFound @User
  
 getRoot :: (JWT.Resolver m, MonadThrow m, MonadLogger m) => JWT -> m JWT
 getRoot jwt@JWT {claims = JWT.Claims {proof}} =

--- a/library/Fission/Web/Auth/UCAN.hs
+++ b/library/Fission/Web/Auth/UCAN.hs
@@ -9,6 +9,8 @@ import           Fission.Web.Error.Class
 import           Fission.Error.NotFound.Types
 
 import qualified Fission.User.Retriever as User
+ 
+import qualified Fission.Web.Error as Web.Error
 
 import qualified Fission.Web.Auth.Token as Token
 import qualified Fission.Web.Auth.Error as Auth
@@ -23,13 +25,6 @@ import           Fission.Web.Auth.Token.JWT.Resolver as JWT
 import           Fission.Authorization.Types
 import           Fission.Authorization.ServerDID
 import           Fission.User.DID.Types
-
-
-
-
-
-import Servant.Server
-import qualified Fission.Web.Error as Web.Error
 
 -- | Auth handler for delegated auth
 -- Ensures properly formatted token *and does check against DB*

--- a/library/Fission/Web/DNS.hs
+++ b/library/Fission/Web/DNS.hs
@@ -22,6 +22,6 @@ type API
   :> Capture "cid" CID
   :> PutAccepted '[PlainText, OctetStream] URL.DomainName
 
-server :: MonadDNSLink m => Authorization -> ServerT API m
+server :: (MonadLogger m, MonadDNSLink m) => Authorization -> ServerT API m
 server Authorization {about = Entity _ User {userUsername = Username rawUN}} cid =
   Web.Err.ensureM =<< DNSLink.setBase (URL.Subdomain rawUN) cid

--- a/library/Fission/Web/Error.hs
+++ b/library/Fission/Web/Error.hs
@@ -15,7 +15,6 @@ import           Servant.Server
 import           Fission.Prelude
 import           Fission.Web.Error.Class
  
-import           Fission.Internal.UTF8 as UTF8
 import           Fission.Internal.Orphanage.ServerError ()
 
 ensure ::

--- a/library/Fission/Web/Error.hs
+++ b/library/Fission/Web/Error.hs
@@ -37,7 +37,15 @@ ensureM ::
   => Either err a -> m a
 ensureM = either throw pure
 
-ensureMaybe :: (MonadLogger m, MonadThrow m) => ServerError -> Maybe a -> m a
+ensureMaybe ::
+  ( MonadLogger m
+  , MonadThrow m
+  , Display       err
+  , ToServerError err
+  )
+  => err
+  -> Maybe a
+  -> m a
 ensureMaybe err = maybe (throw err) pure
 
 throw ::

--- a/library/Fission/Web/Error/Class.hs
+++ b/library/Fission/Web/Error/Class.hs
@@ -10,7 +10,6 @@ import qualified Network.IPFS.Get.Error  as Get
 import qualified Network.IPFS.Peer.Error as Peer
 
 import           Fission.Prelude
-import qualified Fission.Internal.UTF8 as UTF8
 
 class ToServerError err where
   toServerError :: err -> ServerError
@@ -65,10 +64,10 @@ instance ToServerError Error where
 
 instance ToServerError Get.Error where
   toServerError = \case
-    Get.InvalidCID       txt          -> err422 { errBody = UTF8.textToLazyBS txt }
+    Get.InvalidCID       txt          -> err422 { errBody = displayLazyBS txt }
     Get.UnexpectedOutput _            -> err502 { errBody = "Unexpected IPFS result" }
     Get.UnknownErr       _            -> err502 { errBody = "Unknown IPFS error" }
-    Get.TimedOut         (CID hash) _ -> err504 { errBody = "IPFS timed out looking for " <> UTF8.textToLazyBS hash }
+    Get.TimedOut         (CID hash) _ -> err504 { errBody = "IPFS timed out looking for " <> displayLazyBS hash }
 
 instance ToServerError Add.Error where
   toServerError = \case
@@ -76,7 +75,7 @@ instance ToServerError Add.Error where
     Add.UnknownAddErr    _ -> err502 { errBody = "Unknown IPFS error" }
     Add.RecursiveAddErr  _ -> err502 { errBody = "Error while adding directory" }
     Add.UnexpectedOutput _ -> err502 { errBody = "Unexpected IPFS result" }
-    Add.IPFSDaemonErr  msg -> err502 { errBody = "IPFS Daemon Error: " <> UTF8.textToLazyBS msg}
+    Add.IPFSDaemonErr  msg -> err502 { errBody = "IPFS Daemon Error: " <> displayLazyBS msg}
 
 instance ToServerError Peer.Error where
   toServerError = \case

--- a/library/Fission/Web/Log.hs
+++ b/library/Fission/Web/Log.hs
@@ -25,18 +25,18 @@ rioApacheLogger Request {..} Status {..} _mayInt =
       [ displayShow remoteHost
       , " - - "
       , displayShow httpVersion
-      , " "
-      , displayShow requestMethod
-      , " "
-      , displayShow requestHeaders
-      , " "
-      , if rawPathInfo    == "" then "" else displayShow rawPathInfo
-      , if rawQueryString == "" then "" else displayShow rawQueryString
-      , " "
+      , " - - "
       , displayShow statusCode
       , ": "
       , displayShow statusMessage
-      , displayShow $ maybe "" (" - " <>) requestHeaderUserAgent
+      , " "
+      , displayShow requestMethod
+      , " "
+      , if rawPathInfo    == "" then "" else displayShow rawPathInfo
+      , " "
+      , if rawQueryString == "" then "" else displayShow rawQueryString
+      , " "
+      , displayShow requestHeaders
       ]
 
 fromLogFunc :: LogFunc -> ApacheLogger

--- a/library/Fission/Web/Ping/Types.hs
+++ b/library/Fission/Web/Ping/Types.hs
@@ -4,7 +4,6 @@ import           Data.Swagger hiding (name)
 import           Servant
 
 import           Fission.Prelude
-import qualified Fission.Internal.UTF8 as UTF8
 
 -- | A dead-simple text wrapper.
 --   Primarily exists for customized instances.
@@ -27,4 +26,4 @@ instance ToSchema Pong where
       |> pure
 
 instance MimeRender PlainText Pong where
-  mimeRender _proxy = UTF8.textToLazyBS . unPong
+  mimeRender _proxy = displayLazyBS . unPong

--- a/library/Fission/Web/User/Create.hs
+++ b/library/Fission/Web/User/Create.hs
@@ -29,6 +29,7 @@ type PasswordAPI
 
 withDID ::
   ( MonadDNSLink   m
+  , MonadLogger    m
   , MonadTime      m
   , MonadDB      t m
   , User.Creator t

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: fission
-version: '2.3.2'
+version: '2.3.3'
 category: API
 author:
   - Brooklyn Zelenka

--- a/web/Main.hs
+++ b/web/Main.hs
@@ -96,7 +96,7 @@ main = do
         runDB updateDBToLatest
 
         auth <- Auth.mkAuth
-        logDebugN $ layoutWithContext (Proxy @Web.API) auth
+        logDebug @Text $ layoutWithContext (Proxy @Web.API) auth
 
         ServerDID.publicize
 


### PR DESCRIPTION
All auth failures were returning `500`s. Turned out to be a quick fix. Also generalized some helpers.

## Server Logs

```hs
127.0.0.1:65098 - - HTTP/2.0 "PUT" 
  [ ("Host"         , "localhost:1337"  )
  , ("User-Agent"   , "curl/7.64.1"     )
  , ("Accept"       , "*/*"             )
  , ("Authorization", "Bearer eyJ...Otw")
  , ("Content-Type" , "application/json")
  ] 
  "/dns/QmcYMyQmp7ZpCY5mDtGP66UbW6AZzRLrFAmnFHqjgZPTuP" 
  401: "Unauthorized"" - curl/7.64.1"
```

## Client Response

```http
~ » curl -i --http2-prior-knowledge \
  -X PUT \
  -H "Authorization: Bearer eyJ...FOtw" \
  -H "Content-Type: application/json" \
  http://localhost:1337/dns/QmcYMyQmp7ZpCY5mDtGP66UbW6AZzRLrFAmnFHqjgZPTuP

HTTP/2 401
date: Sat, 25 Apr 2020 04:36:43 GMT
server: Warp/3.3.10

Expired
```