### PR TITLE
Flip files DNS

### DIFF
--- a/env.yaml.example
+++ b/env.yaml.example
@@ -7,7 +7,6 @@ server:
 
 ipfs:
   url: http://localhost:5001
-  gateway: ipfs.runfission.com
   timeout: 3600
   remotePeer: /dns4/node.runfission.com/tcp/4001/ipfs/QmVLEz2SxoNiFnuyLpbXsH6SvjPTrHNMU88vCQZyhgBzgw
 

--- a/library/Fission/Authorization.hs
+++ b/library/Fission/Authorization.hs
@@ -13,4 +13,4 @@ import Fission.Authorization.ServerDID
 import Fission.SemVer.Types
 
 latestVersion :: SemVer
-latestVersion = SemVer 0 2 0
+latestVersion = SemVer 1 0 0

--- a/library/Fission/Config/Types.hs
+++ b/library/Fission/Config/Types.hs
@@ -32,7 +32,6 @@ data Config = Config
   , ipfsURL        :: !IPFS.URL
   , ipfsRemotePeer :: !IPFS.Peer
   , ipfsTimeout    :: !IPFS.Timeout
-  , ipfsGateway    :: !IPFS.Gateway
   --
   , herokuID       :: !Heroku.ID
   , herokuPassword :: !Heroku.Password
@@ -68,7 +67,6 @@ instance Show Config where
     , "  ipfsURL           = " <> show ipfsURL
     , "  ipfsRemotePeer    = " <> show ipfsRemotePeer
     , "  ipfsTimeout       = " <> show ipfsTimeout
-    , "  ipfsGateway       = " <> show ipfsGateway
     --
     , "  herokuID          = " <> show herokuID
     , "  herokuPassword    = " <> show herokuPassword

--- a/library/Fission/SemVer.hs
+++ b/library/Fission/SemVer.hs
@@ -7,4 +7,4 @@ module Fission.SemVer
 import Fission.SemVer.Types
 
 current :: SemVer
-current = SemVer 0 1 0
+current = SemVer 1 0 0

--- a/library/Fission/SemVer.hs
+++ b/library/Fission/SemVer.hs
@@ -1,10 +1,4 @@
-module Fission.SemVer
-  ( current
-  -- * Reexports
-  , module Fission.SemVer.Types
-  ) where
+module Fission.SemVer (module Fission.SemVer.Types) where
 
 import Fission.SemVer.Types
 
-current :: SemVer
-current = SemVer 1 0 0

--- a/library/Fission/Types.hs
+++ b/library/Fission/Types.hs
@@ -369,7 +369,7 @@ instance User.Creator Fission where
               userPublic = dataURL `WithPath` ["public"]
               dataURL    = URL
                 { domainName
-                , subdomain  = Just $ Subdomain ("files." <> rawUN)
+                , subdomain  = Just $ Subdomain (rawUN <> ".files")
                 }
 
             DNSLink.follow userId url zoneID userPublic >>= \case

--- a/library/Fission/Types.hs
+++ b/library/Fission/Types.hs
@@ -204,9 +204,7 @@ instance MonadRoute53 Fission where
 
 instance MonadDNSLink Fission where
   set _userId url@URL {..} zoneID (IPFS.CID hash) = do
-    IPFS.Gateway gateway <- asks ipfsGateway
-     
-    Route53.set Cname url zoneID (pure gateway) >>= \case
+    Route53.set Cname url zoneID (pure $ textDisplay gateway) >>= \case
       Left err ->
         return $ Error.openLeft err
 
@@ -216,6 +214,7 @@ instance MonadDNSLink Fission where
           Right _  -> Right url
              
     where
+      gateway    = URL { domainName, subdomain = Just (Subdomain "gateway") }
       dnsLinkURL = URL.prefix' (URL.Subdomain "_dnslink") url
       dnsLink    = "dnslink=/ipfs/" <> hash
 
@@ -445,7 +444,7 @@ instance User.Modifier Fission where
             let
               url = URL
                 { domainName = userDataDomain
-                , subdomain  = Just $ Subdomain ("files." <> username)
+                , subdomain  = Just $ Subdomain (username <> ".files")
                 }
 
             DNSLink.set userId url zoneID newCID <&> \case

--- a/library/Fission/Types.hs
+++ b/library/Fission/Types.hs
@@ -219,9 +219,7 @@ instance MonadDNSLink Fission where
       dnsLink    = "dnslink=/ipfs/" <> hash
 
   follow _userId url@URL {..} zoneID followeeURL = do
-    IPFS.Gateway gateway <- asks ipfsGateway
-
-    Route53.set Cname url zoneID (pure gateway) >>= \case
+    Route53.set Cname url zoneID (pure $ textDisplay gateway) >>= \case
       Left err ->
         return $ Error.openLeft err
 
@@ -231,6 +229,7 @@ instance MonadDNSLink Fission where
           Right _  -> Right ()
 
     where
+      gateway    = URL { domainName, subdomain = Just (Subdomain "gateway") }
       dnsLinkURL = URL.prefix' (URL.Subdomain "_dnslink") url
       dnsLink    = "dnslink=/ipns/" <> textDisplay followeeURL
 

--- a/library/Fission/Web/Auth/Token/JWT/Validation.hs
+++ b/library/Fission/Web/Auth/Token/JWT/Validation.hs
@@ -83,7 +83,7 @@ checkReceiver jwt@JWT {claims = JWT.Claims {receiver}} = do
 
 checkVersion :: JWT -> Either JWT.Error JWT
 checkVersion jwt@JWT { header = JWT.Header {uav = SemVer mjr mnr pch}} =
-  if mjr < 1 && mnr <= 1 && pch <= 0
+  if mjr == 1 && mnr >= 0 && pch <= 0
     then Right jwt
     else Left $ JWT.HeaderError UnsupportedVersion
 

--- a/library/Fission/Web/Auth/Token/JWT/Validation.hs
+++ b/library/Fission/Web/Auth/Token/JWT/Validation.hs
@@ -83,7 +83,7 @@ checkReceiver jwt@JWT {claims = JWT.Claims {receiver}} = do
 
 checkVersion :: JWT -> Either JWT.Error JWT
 checkVersion jwt@JWT { header = JWT.Header {uav = SemVer mjr mnr pch}} =
-  if mjr == 1 && mnr >= 0 && pch <= 0
+  if mjr == 1 && mnr >= 0 && pch >= 0
     then Right jwt
     else Left $ JWT.HeaderError UnsupportedVersion
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: fission
-version: '2.4.1'
+version: '2.4.2'
 category: API
 author:
   - Brooklyn Zelenka

--- a/server/Fission/Internal/Development.hs
+++ b/server/Fission/Internal/Development.hs
@@ -104,7 +104,6 @@ run logFunc dbPool processCtx httpManager action =
     ipfsPath       = "/usr/local/bin/ipfs"
     ipfsURL        = IPFS.URL $ BaseUrl Http "localhost" 5001 ""
     ipfsTimeout    = IPFS.Timeout 3600
-    ipfsGateway    = IPFS.Gateway "ipfs.runfission.com"
     ipfsRemotePeer = IPFS.Peer "/ip4/3.215.160.238/tcp/4001/ipfs/QmVLEz2SxoNiFnuyLpbXsH6SvjPTrHNMU88vCQZyhgBzgw"
 
     awsAccessKey   = "SOME_AWS_ACCESS_KEY"
@@ -164,7 +163,6 @@ mkConfig dbPool processCtx httpManager logFunc = Config {..}
     ipfsURL        = IPFS.URL $ BaseUrl Http "localhost" 5001 ""
     ipfsRemotePeer = IPFS.Peer "/ip4/3.215.160.238/tcp/4001/ipfs/QmVLEz2SxoNiFnuyLpbXsH6SvjPTrHNMU88vCQZyhgBzgw"
     ipfsTimeout    = IPFS.Timeout 3600
-    ipfsGateway    = IPFS.Gateway "ipfs.runfission.com"
 
     baseAppZoneID  = AWS.ZoneID "BASE_APP_ZONE_ID"
     userZoneID     = AWS.ZoneID "USER_ZONE_ID"

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -71,7 +71,6 @@ main = do
     ipfsURL        = env |> ipfs |> url
     ipfsRemotePeer = env |> ipfs |> remotePeer
     ipfsTimeout    = env |> ipfs |> IPFS.timeout
-    ipfsGateway    = env |> ipfs |> gateway
 
     awsAccessKey   = accessKey
     awsSecretKey   = secretKey


### PR DESCRIPTION
AWS doesn't support either multi-domain TLS or TLS with nested wildcards. As a consequence, we need the following changes:

* `files.${username}.fission.name -> ${username}.files.fission.name`
* All CNAMEs now consistently at `gateway.fission.${tld}`
* Drop `ipfsGateway` from the config

And while the hood was up, bumped the supported UCAN epoch to `~1.x`, since that's the correct way to use semver 😅 