### PR TITLE
Increase TTL for CNAME records

### DIFF
--- a/library/Fission/AWS/Route53/Class.hs
+++ b/library/Fission/AWS/Route53/Class.hs
@@ -17,6 +17,7 @@ class MonadAWS m => MonadRoute53 m where
     -> URL
     -> AWS.ZoneID
     -> NonEmpty Text
+    -> Natural
     -> m (Either ServerError ChangeResourceRecordSetsResponse)
 
   clear ::

--- a/library/Fission/Internal/Mock/Config.hs
+++ b/library/Fission/Internal/Mock/Config.hs
@@ -58,7 +58,7 @@ defaultConfig = Config
   , clearRoute53    = \_ _ ->
       Right . changeResourceRecordSetsResponse 200 $ changeInfo "ciId" Insync agesAgo
 
-  , updateRoute53   = \_ _ _ _ ->
+  , updateRoute53   = \_ _ _ _ _ ->
       Right . changeResourceRecordSetsResponse 200 $ changeInfo "ciId" Insync agesAgo
   }
 

--- a/library/Fission/Internal/Mock/Config/Types.hs
+++ b/library/Fission/Internal/Mock/Config/Types.hs
@@ -29,7 +29,7 @@ data Config = Config
   { setDNSLink      :: URL.DomainName -> Maybe URL.Subdomain -> IPFS.CID -> Either DNSLink.Errors URL
   , followDNSLink   :: URL -> Path URL -> Either DNSLink.Errors ()
   , getBaseDomain   :: URL.DomainName
-  , updateRoute53   :: RecordType -> URL -> AWS.ZoneID -> NonEmpty Text -> Either ServerError ChangeResourceRecordSetsResponse
+  , updateRoute53   :: RecordType -> URL -> AWS.ZoneID -> NonEmpty Text -> Natural -> Either ServerError ChangeResourceRecordSetsResponse
   , clearRoute53    :: RecordType -> URL -> Either ServerError ChangeResourceRecordSetsResponse
   , now             :: UTCTime
   , linkedPeers     :: NonEmpty IPFS.Peer

--- a/library/Fission/Internal/Mock/Types.hs
+++ b/library/Fission/Internal/Mock/Types.hs
@@ -132,10 +132,10 @@ instance
   , IsMember ClearRoute53  effs
   )
   => MonadRoute53 (Mock effs) where
-  set r url zone nonEmptyTxts = do
+  set r url zone nonEmptyTxts ttl = do
     Effect.log UpdateRoute53
     runner <- asks updateRoute53
-    return $ runner r url zone nonEmptyTxts
+    return $ runner r url zone nonEmptyTxts ttl
 
   clear r url _ = do
     Effect.log ClearRoute53

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: fission
-version: '2.4.3'
+version: '2.4.4'
 category: API
 author:
   - Brooklyn Zelenka


### PR DESCRIPTION
## Problem
Currently, `foo.fission.app` and friends are only cached for 10s. This makes sense for TXT records, but CNAMEs can be cached for much longer.

## Solution
Increase DNS cache length to 24 hours

Closes https://github.com/fission-suite/fission/issues/336