### PR TITLE
Exchange keys route

### DIFF
--- a/library/Fission/Internal/Fixture/User.hs
+++ b/library/Fission/Internal/Fixture/User.hs
@@ -10,14 +10,11 @@ import qualified Fission.User.Role.Types as User.Roles
 
 import           Fission.Internal.Fixture.Time
 import qualified Fission.Internal.Fixture.Key.Ed25519 as Ed25519
+import qualified Fission.Internal.RSA2048.Pair.Types  as RSA2048
 
 user :: User
 user = User
-  { userPublicKey = Just Ed25519.pk
-
-  --
-
-  , userEmail    = Just "test@fission.codes"
+  { userEmail    = Just "test@fission.codes"
   , userUsername = "testUser"
 
   --
@@ -26,6 +23,10 @@ user = User
   , userActive = True
   , userVerified  = False
 
+  --
+
+  , userPublicKey    = Just Ed25519.pk
+  , userExchangeKeys = [RSA2048.pk1]
   --
 
   , userDataRoot     = CID "QmW2WQi7j6c7UgJTarActp7tDNikE4B2qXtFCfLPdsgaTQ"

--- a/library/Fission/Internal/Mock/Types.hs
+++ b/library/Fission/Internal/Mock/Types.hs
@@ -259,6 +259,14 @@ instance IsMember ModifyUser effs => User.Modifier (Mock effs) where
     Effect.log $ ModifyUser uID
     return $ Right newPK
 
+  addExchangeKey uID key _ = do
+    Effect.log $ ModifyUser uID
+    return $ Right [key]
+
+  removeExchangeKey uID _ _ = do
+    Effect.log $ ModifyUser uID
+    return $ Right []
+
   setData uID _ _ = do
     Effect.log $ ModifyUser uID
     return ok

--- a/library/Fission/Internal/Orphanage/RSA2048/Public.hs
+++ b/library/Fission/Internal/Orphanage/RSA2048/Public.hs
@@ -14,6 +14,9 @@ import qualified Data.PEM as PEM
 import qualified Data.ByteString.Base64 as BS64
 import qualified Data.X509              as X509
 
+import           Data.Swagger
+import           Database.Persist.Postgresql
+
 import qualified RIO.Text as Text
  
 import           Servant.API
@@ -48,6 +51,27 @@ instance FromJSON RSA.PublicKey where
 
 instance ToJSON RSA.PublicKey where
   toJSON = String . textDisplay
+
+instance PersistField RSA.PublicKey where
+  toPersistValue =
+    PersistText . textDisplay
+
+  fromPersistValue (PersistText txt) =
+    parseUrlPiece txt
+   
+  fromPersistValue other =
+    Left $ "Invalid Persistent RSA PK: " <> Text.pack (show other)
+
+instance ToParamSchema RSA.PublicKey where
+  toParamSchema _ = mempty |> type_ ?~ SwaggerString
+
+instance ToSchema RSA.PublicKey where
+  declareNamedSchema _ =
+    mempty
+      |> type_ ?~ SwaggerString
+      |> description ?~ "An RSA public key"
+      |> NamedSchema (Just "RSA.PublicKey")
+      |> pure
 
 pemHeader :: Text
 pemHeader = "-----BEGIN PUBLIC KEY-----"

--- a/library/Fission/Internal/RSA2048/Pair/Types.hs
+++ b/library/Fission/Internal/RSA2048/Pair/Types.hs
@@ -1,4 +1,13 @@
-module Fission.Internal.RSA2048.Pair.Types (Pair (..)) where
+module Fission.Internal.RSA2048.Pair.Types 
+  ( Pair (..)
+  , pregenerated
+  , pk1
+  , sk1
+  , pk2
+  , sk2
+  , pk3
+  , sk3
+  ) where
 
 import Crypto.PubKey.RSA
 

--- a/library/Fission/Models.hs
+++ b/library/Fission/Models.hs
@@ -24,6 +24,7 @@ import           Fission.Platform.Heroku.Region.Types
 import           Fission.Security
 
 import qualified Fission.Key                          as Key
+import qualified Crypto.PubKey.RSA                    as RSA
 import           Fission.URL
 
 import           Fission.User.Email.Types
@@ -34,8 +35,9 @@ import           Fission.Challenge.Types
 import qualified Fission.AWS.Zone.Types               as AWS
 
 import           Fission.Internal.Orphanage.Bytes     ()
-import           Fission.Internal.Orphanage.CID       ()
-import           Fission.Internal.Orphanage.UUID      ()
+import           Fission.Internal.Orphanage.CID            ()
+import           Fission.Internal.Orphanage.UUID           ()
+import           Fission.Internal.Orphanage.RSA2048.Public ()
 
 share
   [ mkPersist       sqlSettings
@@ -57,6 +59,7 @@ HerokuAddOn
 
 User
   publicKey     Key.Public    Maybe
+  exchangeKeys  [RSA.PublicKey]        default=[]
 
   email         Email         Maybe
   username      Username

--- a/library/Fission/User/Creator.hs
+++ b/library/Fission/User/Creator.hs
@@ -42,6 +42,7 @@ createDB ::
 createDB username pk email now =
   User
     { userPublicKey     = Just pk
+    , userExchangeKeys  = []
     , userUsername      = username
     , userEmail         = Just email
     , userRole          = Regular
@@ -80,6 +81,7 @@ createWithPasswordDB username password email now =
     Right secretDigest ->
       User
         { userPublicKey     = Nothing
+        , userExchangeKeys  = []
         , userUsername      = username
         , userEmail         = Just email
         , userRole          = Regular
@@ -119,6 +121,7 @@ createWithHerokuDB herokuUUID herokuRegion username password now =
         Right secretDigest ->
           User
             { userPublicKey     = Nothing
+            , userExchangeKeys  = []
             , userUsername      = username
             , userEmail         = Nothing
             , userRole          = Regular

--- a/library/Fission/User/DID.hs
+++ b/library/Fission/User/DID.hs
@@ -1,6 +1,3 @@
-module Fission.User.DID
-  ( -- * Reexports
-    module Fission.User.DID.Types
-  ) where
+module Fission.User.DID (module Fission.User.DID.Types) where
 
 import Fission.User.DID.Types

--- a/library/Fission/User/DID/Types.hs
+++ b/library/Fission/User/DID/Types.hs
@@ -55,17 +55,17 @@ More here: https://github.com/multiformats/unsigned-varint
 Ed25519
 
 >>> eitherDecode "\"did:key:zStEZpzSMtTt9k2vszgvCwF4fLQQSyA15W5AQ4z3AR6Bx4eFJ5crJFbuGxKmbma4\"" :: Either String DID
-Right (DID {publicKey = Hv+AVRD2WUjUFOsSNbsmrp9fokuwrUnjBcr92f0kxw4=, method = Key})
+Right (DID {method = Key, publicKey = Hv+AVRD2WUjUFOsSNbsmrp9fokuwrUnjBcr92f0kxw4=})
 
 RSA
 
 eitherDecode "\"did:key:z1LBnwEktwYLrpPhuwFowdVwAFX5zpRo9rrVzwiRRBBiaBoCR7hNqgstW7VM3T9auNbqTmQW4vdHb61RhTMVgCp1BTxuaKU3anWoERFXpuZvfE39g8u7HS9BeD1QJN1fX6S8vvskaPhxFkwLtGr4ZffkUE57WZpNWM6U6BqdktZxmKzxC85zN4FC9Ws5LHuGfxaCuBLiUfA7qEYVSz1Qu1rZDpD6NyfUNrHJ1ErZduJun976nbFHrmDnU47RcSMFESbNKDi1467tRfubsMrDzebdCFKQ2m1AYysto2i6Wmcnucjt3tnwTqe7Bo8L1g8h8UGA946DF3WeGbPUGqznsUdLq6XLCmJzJkJmrNyeZkswdyPX2Vu6J9E4J12Sb3h9ds7atByamftitEZsf6hPJkLUXGThYpCnmRAArRRfPY2H6cKDc7AcnFPyNHGkab5ZFo4qvgBZytbK1K5oD3HfQ6E2ybLhyC2b8i5wo6DLtm9ufixSJNNTH7Uikk88CmertKR7s12CK1WLEM3Zu5YBZNphnjj7cp8QTodAehRPV9NG1CLEAMJVN79DvYe6SfiafJobcvfD8npfS6jcejcyouQbEpKDG7QAnKS48P4AvgBqDvfNUe54jMkk6r6CoX4LcYGHukZDEnea9kwkEoXkUYS4j1AfbKh44FzSuXbQqZnjjVpThxCNmmNn1E4qHmsFkvGoF3FN55CPkoGfDCvyQJgqmsFmpeTJSy9wzv4MvbqpuATxr7eyxsGeCWQkcDwub32inGpR3reTfzRJECCFZarnXdcC5Pidakb1Wu8L\""
-Right (DID {publicKey = MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnzyis1ZjfNB0bBgKFMSvvkTtwlvBsaJq7S5wA+kzeVOVpVWwkWdVha4s38XM/pa/yr47av7+z3VTmvDRyAHcaT92whREFpLv9cj5lTeJSibyr/Mrm/YtjCZVWgaOYIhwrXwKLqPr/11inWsAkfIytvHWTxZYEcXLgAXFuUuaS3uF9gEiNQwzGTU1v0FqkqTBr4B8nW3HCN47XUu0t8Y0e+lf4s4OxQawWD79J9/5d3Ry0vbV3Am1FtGJiJvOwRsIfVChDpYStTcHTCMqtvWbV6L11BWkpzGXSW4Hv43qa+GSYOD2QU68Mb59oSk2OB+BtOLpJofmbGEGgvmwyCI9MwIDAQAB, method = Key})
+Right (DID {method = Key, publicKey = MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnzyis1ZjfNB0bBgKFMSvvkTtwlvBsaJq7S5wA+kzeVOVpVWwkWdVha4s38XM/pa/yr47av7+z3VTmvDRyAHcaT92whREFpLv9cj5lTeJSibyr/Mrm/YtjCZVWgaOYIhwrXwKLqPr/11inWsAkfIytvHWTxZYEcXLgAXFuUuaS3uF9gEiNQwzGTU1v0FqkqTBr4B8nW3HCN47XUu0t8Y0e+lf4s4OxQawWD79J9/5d3Ry0vbV3Am1FtGJiJvOwRsIfVChDpYStTcHTCMqtvWbV6L11BWkpzGXSW4Hv43qa+GSYOD2QU68Mb59oSk2OB+BtOLpJofmbGEGgvmwyCI9MwIDAQAB})
 
 -}
 data DID = DID
-  { publicKey :: !Key.Public
-  , method    :: !Method
+  { method    :: !Method
+  , publicKey :: !Key.Public
   } deriving (Show, Eq)
 
 instance Arbitrary DID where
@@ -76,7 +76,7 @@ instance Arbitrary DID where
     return DID {..}
 
 instance Display DID where -- NOTE `pk` here is base2, not base58
-  textDisplay (DID pk method) = header <> UTF8.toBase58Text (BS.pack multicodecW8)
+  textDisplay (DID method pk) = header <> UTF8.toBase58Text (BS.pack multicodecW8)
     where
       header :: Text
       header = "did:" <> textDisplay method <> ":" <> "z"
@@ -112,7 +112,7 @@ instance FromJSON DID where
           nope ->
             fail . show . BS64.encode $ BS.pack nope <> " is not an acceptable did:key"
 
-        return $ DID pk Key
+        return $ DID Key pk
 
 parseKeyW8s :: FromJSON a => ByteString -> JSON.Parser a
 parseKeyW8s = parseJSON . toJSON . decodeUtf8Lenient

--- a/library/Fission/User/Modifier.hs
+++ b/library/Fission/User/Modifier.hs
@@ -1,6 +1,8 @@
 module Fission.User.Modifier
   ( updatePasswordDB
   , updatePublicKeyDB
+  , addExchangeKeyDB
+  , removeExchangeKeyDB
   , setDataDB
   , module Fission.User.Modifier.Class
   ) where
@@ -9,14 +11,18 @@ import           Fission.User.Modifier.Class
 
 import           Fission.Prelude
 import           Fission.Models
+import           Fission.Error
 
-import           Fission.Key           as Key
 import           Fission.Security.Types
+import qualified Fission.Key       as Key
+import qualified Crypto.PubKey.RSA as RSA
 
 import           Database.Persist as Persist
 
 import           Network.IPFS.CID.Types
 import           Network.IPFS.Bytes.Types
+
+import qualified RIO.List as List
 
 
 updatePasswordDB ::
@@ -36,13 +42,65 @@ updatePublicKeyDB ::
   => UserId
   -> Key.Public
   -> UTCTime
-  -> Transaction m ()
-updatePublicKeyDB userID pk now =
+  -> Transaction m (Either Errors Key.Public)
+updatePublicKeyDB userID pk now = do
   update userID
     [ UserPublicKey  =. Just pk
     , UserModifiedAt =. now
     ]
-  
+
+  return $ Right pk
+
+addExchangeKeyDB ::
+     MonadIO m
+  => UserId
+  -> RSA.PublicKey
+  -> UTCTime
+  -> Transaction m (Either Errors [RSA.PublicKey])
+addExchangeKeyDB userID key now =
+  Persist.get userID >>= \case
+    Nothing -> 
+      return . openLeft $ NotFound @User
+
+    Just user -> do
+      let keys = userExchangeKeys user
+      if List.elem key keys
+        then 
+          return $ Right keys
+
+        else do
+          let updated = keys ++ [key]
+          update userID
+            [ UserExchangeKeys =. updated
+            , UserModifiedAt   =. now
+            ]
+          return $ Right updated
+
+removeExchangeKeyDB ::
+    MonadIO m
+  => UserId
+  -> RSA.PublicKey
+  -> UTCTime
+  -> Transaction m (Either Errors [RSA.PublicKey])
+removeExchangeKeyDB userID key now =
+  Persist.get userID >>= \case
+    Nothing -> 
+      return . openLeft $ NotFound @User
+
+    Just user -> do
+      let keys = userExchangeKeys user
+      if List.elem key keys
+        then do
+          let updated = List.delete key keys
+          update userID
+            [ UserExchangeKeys =. updated
+            , UserModifiedAt   =. now
+            ]
+          return $ Right updated
+
+        else 
+          return $ Right keys
+
 setDataDB ::
      MonadIO m
   => UserId

--- a/library/Fission/User/Modifier.hs
+++ b/library/Fission/User/Modifier.hs
@@ -63,13 +63,14 @@ addExchangeKeyDB userID key now =
       return . openLeft $ NotFound @User
 
     Just user -> do
-      let keys = userExchangeKeys user
+      let 
+        keys = userExchangeKeys user
+        updated = [key] ++ keys
       if List.elem key keys
         then 
           return $ Right keys
 
         else do
-          let updated = keys ++ [key]
           update userID
             [ UserExchangeKeys =. updated
             , UserModifiedAt   =. now
@@ -88,10 +89,11 @@ removeExchangeKeyDB userID key now =
       return . openLeft $ NotFound @User
 
     Just user -> do
-      let keys = userExchangeKeys user
+      let 
+        keys = userExchangeKeys user
+        updated = List.delete key keys
       if List.elem key keys
         then do
-          let updated = List.delete key keys
           update userID
             [ UserExchangeKeys =. updated
             , UserModifiedAt   =. now

--- a/library/Fission/User/Modifier.hs
+++ b/library/Fission/User/Modifier.hs
@@ -65,7 +65,7 @@ addExchangeKeyDB userID key now =
     Just user -> do
       let 
         keys = userExchangeKeys user
-        updated = [key] ++ keys
+        updated = key : keys
       if List.elem key keys
         then 
           return $ Right keys

--- a/library/Fission/User/Modifier/Class.hs
+++ b/library/Fission/User/Modifier/Class.hs
@@ -13,7 +13,9 @@ import           Fission.Error
 import           Fission.Models
 import           Fission.Prelude
 
-import           Fission.Key           as Key
+import qualified Fission.Key           as Key
+import qualified Crypto.PubKey.RSA     as RSA
+
 import           Fission.URL
 import           Fission.User.Password as Password
 
@@ -43,6 +45,18 @@ class Monad m => Modifier m where
     -> Key.Public
     -> UTCTime
     -> m (Either Errors Key.Public)
+
+  addExchangeKey ::
+       UserId
+    -> RSA.PublicKey
+    -> UTCTime
+    -> m (Either Errors [RSA.PublicKey])
+
+  removeExchangeKey ::
+       UserId
+    -> RSA.PublicKey
+    -> UTCTime
+    -> m (Either Errors [RSA.PublicKey])
    
   setData ::
        UserId

--- a/library/Fission/Web/Auth/Token/JWT.hs
+++ b/library/Fission/Web/Auth/Token/JWT.hs
@@ -83,7 +83,7 @@ instance Arbitrary JWT where
     claims' <- arbitrary
 
     let
-      claims = claims' {sender = DID pk Key}
+      claims = claims' {sender = DID Key pk}
    
       sig' = case sk of
         Left rsaSK -> Unsafe.unsafePerformIO $ signRS256 header claims rsaSK

--- a/library/Fission/Web/User.hs
+++ b/library/Fission/Web/User.hs
@@ -21,13 +21,14 @@ import           Fission.Email
 import qualified Fission.Challenge.Creator.Class  as Challenge
 import qualified Fission.Challenge.Verifier.Class as Challenge
 
-import qualified Fission.Web.User.Create          as Create
-import qualified Fission.Web.User.Verify          as Verify
-import qualified Fission.Web.User.VerifyEmail     as VerifyEmail
-import qualified Fission.Web.User.Password.Reset  as Reset
-import qualified Fission.Web.User.UpdatePublicKey as UpdatePublicKey
-import qualified Fission.Web.User.UpdateData      as UpdateData
-import qualified Fission.Web.User.WhoAmI          as WhoAmI
+import qualified Fission.Web.User.Create             as Create
+import qualified Fission.Web.User.Verify             as Verify
+import qualified Fission.Web.User.VerifyEmail        as VerifyEmail
+import qualified Fission.Web.User.Password.Reset     as Reset
+import qualified Fission.Web.User.UpdatePublicKey    as UpdatePublicKey
+import qualified Fission.Web.User.UpdateExchangeKeys as UpdateExchangeKeys
+import qualified Fission.Web.User.UpdateData         as UpdateData
+import qualified Fission.Web.User.WhoAmI             as WhoAmI
 
 import qualified Fission.Web.Auth.Types as Auth
 
@@ -39,6 +40,7 @@ type API
  :<|> VerifyRoute
  :<|> VerifyEmailRoute
  :<|> UpdatePublicKeyRoute
+ :<|> UpdateExchangeKeysRoute
  :<|> UpdateDataRoute
  :<|> ResetRoute
 
@@ -69,6 +71,12 @@ type UpdatePublicKeyRoute
     :> Auth
     :> UpdatePublicKey.API
 
+type UpdateExchangeKeysRoute
+  = "exchange"
+    :> "keys"
+    :> Auth
+    :> UpdateExchangeKeys.API
+
 type UpdateDataRoute
   = "data"
     :> Auth
@@ -96,5 +104,6 @@ server = Create.withDID
     :<|> (\_ -> Verify.server)
     :<|> VerifyEmail.server
     :<|> UpdatePublicKey.server
+    :<|> UpdateExchangeKeys.server
     :<|> UpdateData.server
     :<|> Reset.server

--- a/library/Fission/Web/User/UpdateExchangeKeys.hs
+++ b/library/Fission/Web/User/UpdateExchangeKeys.hs
@@ -23,13 +23,13 @@ type API = AddAPI :<|> RemoveAPI
 type AddAPI
   =  Summary "Add Public Exchange Key"
   :> Description "Add a key to the currently authenticated user's root list of public exchange keys"
-  :> Capture "public-did-key" RSA.PublicKey
+  :> Capture "did" RSA.PublicKey
   :> Put     '[JSON] [RSA.PublicKey]
 
 type RemoveAPI
   =  Summary "Remove Public Exchange Key"
   :> Description "Remove a key from the currently authenticated user's root list of public exchange keys"
-  :> Capture "public-did-key" RSA.PublicKey
+  :> Capture "did" RSA.PublicKey
   :> Delete  '[JSON] [RSA.PublicKey]
 
 server ::

--- a/library/Fission/Web/User/UpdateExchangeKeys.hs
+++ b/library/Fission/Web/User/UpdateExchangeKeys.hs
@@ -1,0 +1,67 @@
+module Fission.Web.User.UpdateExchangeKeys
+  ( API
+  , AddAPI
+  , RemoveAPI
+  , server
+  , addKey
+  , removeKey
+  ) where
+
+import           Servant
+
+import           Fission.Prelude
+import           Fission.Models
+import           Fission.Authorization
+ 
+import qualified Fission.Web.Error as Web.Error
+import qualified Fission.User      as User
+
+import qualified Crypto.PubKey.RSA as RSA
+
+type API = AddAPI :<|> RemoveAPI
+
+type AddAPI
+  =  Summary "Add Public Exchange Key"
+  :> Description "Add a key to the currently authenticated user's root list of public exchange keys"
+  :> Capture "public-did-key" RSA.PublicKey
+  :> Put     '[JSON] [RSA.PublicKey]
+
+type RemoveAPI
+  =  Summary "Remove Public Exchange Key"
+  :> Description "Remove a key from the currently authenticated user's root list of public exchange keys"
+  :> Capture "public-did-key" RSA.PublicKey
+  :> Delete  '[JSON] [RSA.PublicKey]
+
+server ::
+  ( MonadTime     m
+  , MonadLogger   m
+  , MonadThrow    m
+  , User.Modifier m
+  )
+  => Authorization
+  -> ServerT API m
+server Authorization {about = Entity userId _} = addKey userId :<|> removeKey userId
+
+addKey ::
+  ( MonadTime     m
+  , MonadLogger   m
+  , MonadThrow    m
+  , User.Modifier m
+  )
+  => UserId
+  -> ServerT AddAPI m
+addKey userId key = do
+  now <- currentTime
+  Web.Error.ensureM $ User.addExchangeKey userId key now
+
+removeKey ::
+  ( MonadTime     m
+  , MonadLogger   m
+  , MonadThrow    m
+  , User.Modifier m
+  )
+  => UserId
+  -> ServerT RemoveAPI m
+removeKey userId key = do
+  now <- currentTime
+  Web.Error.ensureM $ User.removeExchangeKey userId key now

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -104,7 +104,7 @@ main = do
 
     withDBPool baseLogger pgConnectInfo (PoolSize 4) \dbPool -> do
       let
-        DID serverPK _ = fissionDID
+        DID _ serverPK = fissionDID
         cfg = Config {..}
        
       runFission cfg do

--- a/test/Test/Fission/User/DID.hs
+++ b/test/Test/Fission/User/DID.hs
@@ -22,7 +22,7 @@ tests =
             expected :: Lazy.ByteString
             expected = "did:key:z13V3Sog2YaUKhdGCmgx9UZuW1o1ShFJYc6DvGYe7NTt689NoL2RtpVs65Zw899YrTN9WuxdEEDm54YxWuQHQvcKfkZwa8HTgokHxGDPEmNLhvh69zUMEP4zjuARQ3T8bMUumkSLGpxNe1bfQX624ef45GhWb3S9HM3gvAJ7Qftm8iqnDQVcxwKHjmkV4hveKMTix4bTRhieVHi1oqU4QCVy4QPWpAAympuCP9dAoJFxSP6TNBLY9vPKLazsg7XcFov6UuLWsEaxJ5SomCpDx181mEgW2qTug5oQbrJwExbD9CMgXHLVDE2QgLoQMmgsrPevX57dH715NXC2uY6vo2mYCzRY4KuDRUsrkuYCkewL8q2oK1BEDVvi3Sg8pbC9QYQ5mMiHf8uxiHxTAmPedv8"
           in
-            encode (DID rsaKey Key) `shouldBe` "\"" <> expected <> "\""
+            encode (DID Key rsaKey) `shouldBe` "\"" <> expected <> "\""
 
       context "ED25519" do
         it "serializes to a well-known value"
@@ -30,7 +30,7 @@ tests =
             expected :: Text
             expected = "did:key:zStEZpzSMtTt9k2vszgvCwF4fLQQSyA15W5AQ4z3AR6Bx4eFJ5crJFbuGxKmbma4"
           in
-            encode (DID edKey Key) `shouldBe` JSON.encode expected
+            encode (DID Key edKey) `shouldBe` JSON.encode expected
 
       itsProp' "serialized is isomorphic to ADT" \(did :: DID) ->
         JSON.decode (JSON.encode did) == Just did

--- a/test/Test/Fission/Web/Auth.hs
+++ b/test/Test/Fission/Web/Auth.hs
@@ -65,7 +65,7 @@ tests = do
 
         context "DID auth" do
           it "uses the encapsulated function" do
-            didResult `shouldBe` Right (DID Ed25519.pk Key)
+            didResult `shouldBe` Right (DID Key Ed25519.pk)
 
         context "heroku auth" do
           it "uses the encapsulated function" do


### PR DESCRIPTION
## Problem
User's need to be able to share their public exchange keys over DNS

## Solution
Add a PATCH /user/exchange root

This will function similarly to PATCH /user/did

It should take an array of did:keys as a parameter, and update the TXT record at `_exchange.${username}.fission.name` to include those keys

Closes https://github.com/fission-suite/fission/issues/341