### PR TITLE
Email verification

### DIFF
--- a/env.yaml.example
+++ b/env.yaml.example
@@ -34,3 +34,7 @@ fission_file_system:
 web_app:
   base_app_domain_name: fission.app
   app_placeholder_cid: QmRVvvMeMEPi1zerpXYH9df3ATdzuB63R1wf3Mz5NS5HQN # Fission logo on a blank page
+
+send_in_blue:
+  api_key: xkeysib-KEY
+  base_url: https://api.sendinblue.com 

--- a/library/Fission/CLI/Command/Setup.hs
+++ b/library/Fission/CLI/Command/Setup.hs
@@ -86,7 +86,7 @@ createAccount = do
 
   sendRequestM (authClient (Proxy @User.Register) `withPayload` form) >>= \case
     Right _ok ->
-      CLI.Success.putOk "Registration successful!"
+      CLI.Success.putOk "Registration successful! Head over to your email to confirm your account."
 
     Left err ->
       let

--- a/library/Fission/Challenge.hs
+++ b/library/Fission/Challenge.hs
@@ -1,0 +1,23 @@
+module Fission.Challenge
+  ( module Fission.Challenge.Types
+  , module Fission.Challenge.Creator.Class
+  , module Fission.Challenge.Verifier.Class
+  , verificationLink
+  ) where
+
+import Fission.Challenge.Types
+import Fission.Challenge.Creator.Class
+import Fission.Challenge.Verifier.Class
+
+import Fission.Prelude
+import Servant         hiding (route)
+
+import qualified Fission.Web.Routes   as Web 
+import qualified Fission.Internal.API as API
+import qualified Fission.Web.User     as User
+
+verificationLink :: Challenge -> Text
+verificationLink challenge = 
+  toUrlPiece $ API.mkLink route challenge
+  where 
+    route = Proxy @(Web.UserPrefix :> User.VerifyEmailRoute)

--- a/library/Fission/Challenge/Creator/Class.hs
+++ b/library/Fission/Challenge/Creator/Class.hs
@@ -1,0 +1,29 @@
+module Fission.Challenge.Creator.Class (Creator (..)) where
+
+import           Fission.Prelude
+import           Fission.Error.Types
+import qualified Fission.Random as Random
+
+import           Fission.Models as Models
+import           Database.Esqueleto
+
+import           Fission.Challenge.Types
+
+
+class Monad m => Creator m where
+  create :: UserId -> m (Either (AlreadyExists UserChallenge) Challenge)
+
+instance MonadIO m => Creator (Transaction m) where
+  create userId = do
+    challenge <- mkChallenge
+    UserChallenge
+      { userChallengeUserId = userId
+      , userChallengeHash   = challenge
+      }
+      |> insertUnique
+      |> bind  \case
+        Nothing -> return $ Left AlreadyExists
+        Just _  -> return $ Right challenge
+
+mkChallenge :: MonadIO m => m Challenge
+mkChallenge = Challenge <$> Random.alphaNum 32

--- a/library/Fission/Challenge/Types.hs
+++ b/library/Fission/Challenge/Types.hs
@@ -1,0 +1,63 @@
+module Fission.Challenge.Types (Challenge(..)) where
+  
+import           Database.Persist.Class
+import           Database.Persist.Types
+import           Database.Persist.Sql
+
+import qualified RIO.ByteString.Lazy as Lazy
+import qualified RIO.Text            as Text
+
+import qualified Network.IPFS.Internal.UTF8 as UTF8
+
+import           Data.Swagger
+import           Servant
+
+import           Fission.Prelude
+
+
+newtype Challenge = Challenge { unChallenge :: Text }
+  deriving newtype  ( Eq
+                    , Show
+                    , IsString
+                    , ToHttpApiData
+                    )
+
+instance Arbitrary Challenge where
+  arbitrary = Challenge <$> arbitrary
+
+instance ToJSON Challenge where
+  toJSON (Challenge challenge') = String challenge'
+
+instance FromJSON Challenge where
+  parseJSON = withText "Challenge" (pure . Challenge)
+
+instance FromHttpApiData Challenge where
+  parseUrlPiece = Right . Challenge
+
+instance PersistField Challenge where
+  toPersistValue (Challenge challenge') = PersistText challenge'
+  fromPersistValue = \case
+    PersistText challenge' -> Right (Challenge challenge')
+    other                  -> Left ("Invalid Persistent Challenge: " <> Text.pack (show other))
+
+instance PersistFieldSql Challenge where
+  sqlType _pxy = SqlString
+
+instance MimeRender PlainText Challenge where
+  mimeRender _ = UTF8.textToLazyBS . unChallenge
+
+instance MimeUnrender PlainText Challenge where
+  mimeUnrender _ = bimap show Challenge . decodeUtf8' . Lazy.toStrict
+
+instance ToParamSchema Challenge where
+  toParamSchema _ = mempty |> type_ ?~ SwaggerString
+
+instance ToSchema Challenge where
+  declareNamedSchema _ =
+    mempty
+      |> type_       ?~ SwaggerString
+      |> description ?~ "A hash representing a user challenge. Sent in a verification email"
+      |> example     ?~ toJSON (Challenge "KyGig3J8lx3K07gZMK1lJV9M6Pr8w2RB")
+      |> NamedSchema (Just "Challenge")
+      |> pure
+

--- a/library/Fission/Challenge/Verifier/Class.hs
+++ b/library/Fission/Challenge/Verifier/Class.hs
@@ -1,0 +1,32 @@
+module Fission.Challenge.Verifier.Class (Verifier (..)) where
+
+import           Database.Persist
+
+import           Fission.Prelude
+import           Fission.Error as Error
+import           Fission.Models
+import           Fission.Challenge.Types
+
+
+class Monad m => Verifier m where
+  verify :: Challenge -> m (Either (NotFound UserChallenge) ())
+
+instance MonadIO m => Verifier (Transaction m) where
+  verify challenge = do
+    res <- selectFirst [ UserChallengeHash ==. challenge ] [] 
+    case res of
+      Nothing -> 
+        return $ Left NotFound
+
+      Just (Entity challengeId UserChallenge { userChallengeHash, userChallengeUserId }) -> 
+        if challenge == userChallengeHash
+          then do
+            update userChallengeUserId
+              [ UserVerified  =. True ]
+
+            delete challengeId
+
+            return ok
+
+          else
+            return $ Left NotFound

--- a/library/Fission/Config/Types.hs
+++ b/library/Fission/Config/Types.hs
@@ -20,12 +20,15 @@ import qualified Fission.AWS.Types as AWS
 import           Fission.URL.Types as URL
 import           Fission.Web.Types
 
+import qualified Fission.Email.SendInBlue.Types as SIB
+
 -- | The top level 'Fission' application 'RIO' configuration
 data Config = Config
   { processCtx     :: !ProcessContext
   , logFunc        :: !LogFunc
   --
   , httpManager    :: !HTTP.Manager
+  , tlsManager     :: !HTTP.Manager
   , dbPool         :: !(Pool SqlBackend)
   --
   , ipfsPath       :: !IPFS.BinPath
@@ -48,6 +51,10 @@ data Config = Config
   , userZoneID     :: !AWS.ZoneID
   , defaultDataCID :: !CID
   --
+  , sibApiKey      :: !SIB.ApiKey
+  , sibUrl         :: !Host
+  , sibTemplateId  :: !SIB.TemplateId
+  --
   , host           :: !Host
   , fissionDID     :: !DID
   , serverZoneID   :: !AWS.ZoneID
@@ -61,6 +68,7 @@ instance Show Config where
     , "  logFunc           = **SOME LOG FUNCTION**"
     --
     , "  httpManager       = **SOME HTTP MANAGER**"
+    , "  tlsManager        = **SOME HTTP/TLS MANAGER**"
     , "  dbPool            = " <> show dbPool
     --
     , "  ipfsPath          = " <> show ipfsPath
@@ -82,6 +90,10 @@ instance Show Config where
     , "  userRootDomain    = " <> show userRootDomain
     , "  userZoneID        = " <> show userZoneID
     , "  defaultDataCID    = " <> show defaultDataCID
+    --
+    , "  sibApiKey         = " <> show sibApiKey
+    , "  sibUrl            = " <> show sibUrl
+    , "  sibTemplateId     = " <> show sibTemplateId
     --
     , "  host              = " <> show host
     , "  fissionDID        = " <> show fissionDID

--- a/library/Fission/Email.hs
+++ b/library/Fission/Email.hs
@@ -1,0 +1,9 @@
+module Fission.Email 
+  ( module Fission.Email.Class
+  , module Fission.Email.Types
+  , module Fission.Email.SendInBlue.Client
+  ) where
+
+import Fission.Email.Class
+import Fission.Email.Types
+import Fission.Email.SendInBlue.Client

--- a/library/Fission/Email/Class.hs
+++ b/library/Fission/Email/Class.hs
@@ -1,0 +1,11 @@
+module Fission.Email.Class (MonadEmail (..)) where
+
+import           Fission.Prelude
+import           Servant.Client
+
+import           Fission.Email.Recipient.Types
+import           Fission.Email.SendInBlue.Types as SIB
+import           Fission.Challenge.Types
+
+class Monad m => MonadEmail m where
+  sendVerificationEmail :: Recipient -> Challenge -> m (Either ClientError SIB.Response)

--- a/library/Fission/Email/Recipient/Types.hs
+++ b/library/Fission/Email/Recipient/Types.hs
@@ -1,0 +1,16 @@
+module Fission.Email.Recipient.Types (Recipient(..)) where
+
+import Fission.Prelude
+import Fission.User.Email.Types
+import Fission.User.Username.Types
+
+data Recipient = Recipient 
+  { email :: !Email
+  , name  :: !Username
+  }
+
+instance ToJSON Recipient where
+  toJSON Recipient { email, name } =
+    Object [ ("email", toJSON email)
+           , ("name",  toJSON name)
+           ]

--- a/library/Fission/Email/SendInBlue/ApiKey/Types.hs
+++ b/library/Fission/Email/SendInBlue/ApiKey/Types.hs
@@ -1,0 +1,13 @@
+module Fission.Email.SendInBlue.ApiKey.Types (ApiKey(..)) where
+
+import Fission.Prelude
+
+newtype ApiKey = ApiKey { unApiKey :: Text }
+  deriving newtype  ( Eq
+                    , Show
+                    , IsString
+                    )
+
+instance FromJSON ApiKey where
+  parseJSON = withText "ApiKey" (pure . ApiKey)
+

--- a/library/Fission/Email/SendInBlue/Client.hs
+++ b/library/Fission/Email/SendInBlue/Client.hs
@@ -1,0 +1,22 @@
+module Fission.Email.SendInBlue.Client 
+  ( SendEmailAPI
+  , sendEmail
+  ) where
+
+import Fission.Prelude
+import Fission.Email.SendInBlue.Types as Email
+
+import Servant
+import Servant.Client
+
+
+type SendEmailAPI
+  = "v3"
+  :> "smtp"
+  :> "email"
+  :> Header "api-key" Text
+  :> ReqBody '[JSON] Email.Request
+  :> Post    '[JSON] Email.Response
+
+sendEmail :: ApiKey -> Email.Request -> ClientM Email.Response
+sendEmail (ApiKey key) = (client $ Proxy @SendEmailAPI) (Just key)

--- a/library/Fission/Email/SendInBlue/Request/Types.hs
+++ b/library/Fission/Email/SendInBlue/Request/Types.hs
@@ -1,0 +1,24 @@
+module Fission.Email.SendInBlue.Request.Types (Request(..)) where
+
+import           Fission.Prelude hiding (to)
+
+import           Fission.Email.Recipient.Types
+import           Fission.Email.SendInBlue.TemplateOptions.Types
+import           Fission.Email.SendInBlue.TemplateId.Types
+
+import qualified RIO.NonEmpty as NonEmpty
+import qualified Data.Vector  as Vector
+
+
+data Request = Request
+  { templateId :: !TemplateId
+  , to         :: !(NonEmpty Recipient)
+  , params     :: !TemplateOptions
+  } 
+
+instance ToJSON Request where
+  toJSON Request { templateId, to, params } =
+    Object [ ("templateId", Number $ fromIntegral (unTemplateId templateId))
+           , ("to",         Array . Vector.fromList $ NonEmpty.toList (toJSON <$> to))
+           , ("params",     toJSON params)
+           ]

--- a/library/Fission/Email/SendInBlue/Response/Types.hs
+++ b/library/Fission/Email/SendInBlue/Response/Types.hs
@@ -1,0 +1,18 @@
+module Fission.Email.SendInBlue.Response.Types (Response(..)) where
+
+import Fission.Prelude
+
+
+newtype Response = Response { messageId :: Text }
+  deriving newtype  ( Eq
+                    , Show
+                    , IsString
+                    , Display
+                    )
+
+instance FromJSON Response where
+  parseJSON = withObject "Response" \obj -> do
+    messageId <- obj .:  "messageId"
+
+    return Response {..}
+

--- a/library/Fission/Email/SendInBlue/TemplateId/Types.hs
+++ b/library/Fission/Email/SendInBlue/TemplateId/Types.hs
@@ -1,0 +1,10 @@
+module Fission.Email.SendInBlue.TemplateId.Types (TemplateId(..)) where
+
+import Fission.Prelude
+
+
+newtype TemplateId = TemplateId { unTemplateId :: Int64 }
+  deriving newtype  ( Eq
+                    , Show
+                    , FromJSON
+                    )

--- a/library/Fission/Email/SendInBlue/TemplateOptions/Types.hs
+++ b/library/Fission/Email/SendInBlue/TemplateOptions/Types.hs
@@ -1,0 +1,18 @@
+module Fission.Email.SendInBlue.TemplateOptions.Types (TemplateOptions(..)) where 
+
+import           Fission.Prelude
+
+import           Fission.User.Username.Types
+import           Servant.Client
+
+
+data TemplateOptions = TemplateOptions
+  { verifyLink :: !BaseUrl 
+  , username   :: !Username 
+  } 
+
+instance ToJSON TemplateOptions where
+  toJSON TemplateOptions { verifyLink, username } =
+    Object [ ("VERIFY_LINK", toJSON verifyLink )
+           , ("USERNAME",    toJSON username )
+           ]

--- a/library/Fission/Email/SendInBlue/Types.hs
+++ b/library/Fission/Email/SendInBlue/Types.hs
@@ -1,0 +1,13 @@
+module Fission.Email.SendInBlue.Types 
+  ( module Fission.Email.SendInBlue.Request.Types
+  , module Fission.Email.SendInBlue.TemplateOptions.Types
+  , module Fission.Email.SendInBlue.Response.Types
+  , module Fission.Email.SendInBlue.ApiKey.Types
+  , module Fission.Email.SendInBlue.TemplateId.Types
+  ) where
+
+import Fission.Email.SendInBlue.Request.Types
+import Fission.Email.SendInBlue.TemplateOptions.Types
+import Fission.Email.SendInBlue.Response.Types
+import Fission.Email.SendInBlue.ApiKey.Types
+import Fission.Email.SendInBlue.TemplateId.Types

--- a/library/Fission/Email/Types.hs
+++ b/library/Fission/Email/Types.hs
@@ -1,0 +1,7 @@
+module Fission.Email.Types 
+  ( module Fission.Email.Recipient.Types
+  , module Fission.Email.SendInBlue.Types
+  ) where
+
+import Fission.Email.Recipient.Types
+import Fission.Email.SendInBlue.Types

--- a/library/Fission/Error/AlreadyExists/Types.hs
+++ b/library/Fission/Error/AlreadyExists/Types.hs
@@ -21,6 +21,9 @@ instance Display (AlreadyExists entity) => ToServerError (AlreadyExists entity) 
 instance Display (AlreadyExists User) where
   display _ = "User already exists"
 
+instance Display (AlreadyExists UserChallenge) where
+  display _ = "Challenge already exists"
+
 instance Display (AlreadyExists LoosePin) where
   display _ = "Loose pin already exists"
 

--- a/library/Fission/Error/NotFound/Types.hs
+++ b/library/Fission/Error/NotFound/Types.hs
@@ -21,6 +21,9 @@ instance ToServerError (NotFound entity) where
 instance Display (NotFound User) where
   display _ = "User not found"
 
+instance Display (NotFound UserChallenge) where
+  display _ = "Challenge not found"
+
 instance Display (NotFound LoosePin) where
   display _ = "Loose pin not found"
 

--- a/library/Fission/Internal/API.hs
+++ b/library/Fission/Internal/API.hs
@@ -1,0 +1,9 @@
+module Fission.Internal.API (mkLink) where
+
+import Fission.Prelude 
+import Servant         hiding (route)
+
+import qualified Fission.Web.Routes as Web 
+
+mkLink :: (IsElem route Web.API, HasLink route) => Proxy route -> MkLink route Link
+mkLink pxy = safeLink (Proxy @Web.API) pxy

--- a/library/Fission/Internal/Fixture/User.hs
+++ b/library/Fission/Internal/Fixture/User.hs
@@ -19,6 +19,7 @@ user = User
 
   , userRole   = User.Roles.Regular
   , userActive = True
+  , userVerified  = False
 
   --
 

--- a/library/Fission/Models.hs
+++ b/library/Fission/Models.hs
@@ -28,6 +28,7 @@ import           Fission.URL
 import           Fission.User.Email.Types
 import           Fission.User.Role.Types
 import           Fission.User.Username.Types
+import           Fission.Challenge.Types
 
 import qualified Fission.AWS.Zone.Types               as AWS
 
@@ -60,6 +61,7 @@ User
 
   role          Role
   active        Bool
+  verified      Bool
 
   dataRoot      CID
 
@@ -72,6 +74,17 @@ User
   UniqueUsername  username
   UniquePublicKey publicKey !force
   -- UniqueEmail     email     !force -- FIXME
+
+  deriving Show Eq
+
+--------------------------------------------------------------------------------
+
+UserChallenge
+  userId    UserId
+  hash      Challenge
+
+  UniqueUserId    userId
+  UniqueChallenge hash
 
   deriving Show Eq
 

--- a/library/Fission/User/Creator/Class.hs
+++ b/library/Fission/User/Creator/Class.hs
@@ -88,6 +88,7 @@ instance
       , userEmail         = Just email
       , userRole          = Regular
       , userActive        = True
+      , userVerified      = False
       , userHerokuAddOnId = Nothing
       , userSecretDigest  = Nothing
       , userDataRoot      = App.Content.empty
@@ -126,6 +127,7 @@ instance
           , userEmail         = Just email
           , userRole          = Regular
           , userActive        = True
+          , userVerified      = False
           , userHerokuAddOnId = Nothing
           , userSecretDigest  = Just secretDigest
           , userDataRoot      = App.Content.empty
@@ -159,6 +161,7 @@ instance
               , userEmail         = Nothing
               , userRole          = Regular
               , userActive        = True
+              , userVerified      = True
               , userHerokuAddOnId = Just herokuAddOnId
               , userSecretDigest  = Just secretDigest
               , userDataRoot      = App.Content.empty

--- a/library/Fission/User/Modifier/Class.hs
+++ b/library/Fission/User/Modifier/Class.hs
@@ -79,4 +79,3 @@ instance MonadIO m => Modifier (Transaction m) where
       }
 
     return ok
-

--- a/library/Fission/Web.hs
+++ b/library/Fission/Web.hs
@@ -28,6 +28,9 @@ import qualified Fission.User                  as User
 import qualified Fission.LoosePin              as LoosePin
 import qualified Fission.Platform.Heroku.AddOn as Heroku.AddOn
 
+import           Fission.Email
+import qualified Fission.Challenge as Challenge
+
 import qualified Fission.Web.Auth    as Auth
 import qualified Fission.Web.DNS     as DNS
 import qualified Fission.Web.Heroku  as Heroku
@@ -53,7 +56,10 @@ app ::
   , MonadDNSLink              m
   , MonadLogger               m
   , MonadTime                 m
+  , MonadEmail                m
   , User.CRUD                 m
+  , Challenge.Creator         m
+  , Challenge.Verifier        m
   , MonadDB                 t m
   , MonadLogger             t
   , MonadThrow              t
@@ -87,7 +93,10 @@ server ::
   , MonadDNSLink              m
   , MonadLogger               m
   , MonadTime                 m
+  , MonadEmail                m
   , User.CRUD                 m
+  , Challenge.Creator         m
+  , Challenge.Verifier        m
   , MonadDB                 t m
   , MonadLogger             t
   , MonadThrow              t
@@ -114,7 +123,10 @@ bizServer ::
   , MonadDNSLink              m
   , MonadLogger               m
   , MonadTime                 m
+  , MonadEmail                m
   , User.CRUD                 m
+  , Challenge.Creator         m
+  , Challenge.Verifier        m
   , MonadDB                 t m
   , MonadLogger             t
   , MonadThrow              t

--- a/library/Fission/Web/Redirect.hs
+++ b/library/Fission/Web/Redirect.hs
@@ -1,0 +1,11 @@
+module Fission.Web.Redirect (redirect) where
+
+import Fission.Prelude
+import Servant
+
+-- Servant treats all non-200s as "errors" so we redirect by "throwing" a 301
+redirect :: 
+     MonadThrow m
+  => ByteString
+  -> m ()
+redirect location = throwM err301 { errHeaders = [("Location", location)] }

--- a/library/Fission/Web/User.hs
+++ b/library/Fission/Web/User.hs
@@ -3,6 +3,7 @@ module Fission.Web.User
   , Auth
   , RegisterRoute
   , VerifyRoute
+  , VerifyEmailRoute
   , UpdatePublicKeyRoute
   , ResetRoute
   , WhoAmIRoute
@@ -15,9 +16,14 @@ import           Fission.Prelude
 import           Fission.IPFS.DNSLink.Class as DNSLink
 
 import qualified Fission.User as User
+import           Fission.Email
+
+import qualified Fission.Challenge.Creator.Class  as Challenge
+import qualified Fission.Challenge.Verifier.Class as Challenge
 
 import qualified Fission.Web.User.Create          as Create
 import qualified Fission.Web.User.Verify          as Verify
+import qualified Fission.Web.User.VerifyEmail     as VerifyEmail
 import qualified Fission.Web.User.Password.Reset  as Reset
 import qualified Fission.Web.User.UpdatePublicKey as UpdatePublicKey
 import qualified Fission.Web.User.UpdateData      as UpdateData
@@ -25,11 +31,13 @@ import qualified Fission.Web.User.WhoAmI          as WhoAmI
 
 import qualified Fission.Web.Auth.Types as Auth
 
+
 type API
   =   RegisterRoute
  :<|> Create.PasswordAPI
  :<|> WhoAmIRoute
  :<|> VerifyRoute
+ :<|> VerifyEmailRoute
  :<|> UpdatePublicKeyRoute
  :<|> UpdateDataRoute
  :<|> ResetRoute
@@ -51,6 +59,11 @@ type VerifyRoute
     :> Auth
     :> Verify.API
 
+type VerifyEmailRoute
+  = "email"
+    :> "verify"
+    :> VerifyEmail.API
+
 type UpdatePublicKeyRoute
   = "did"
     :> Auth
@@ -67,17 +80,21 @@ type ResetRoute
     :> Reset.API
 
 server ::
-  ( MonadDNSLink  m
-  , MonadLogger   m
-  , MonadTime     m
-  , User.Modifier m
-  , User.Creator  m
+  ( MonadDNSLink       m
+  , MonadLogger        m
+  , MonadTime          m
+  , MonadEmail         m
+  , User.Modifier      m
+  , User.Creator       m
+  , Challenge.Creator  m
+  , Challenge.Verifier m
   )
   => ServerT API m
 server = Create.withDID
     :<|> Create.withPassword
     :<|> WhoAmI.server
     :<|> (\_ -> Verify.server)
+    :<|> VerifyEmail.server
     :<|> UpdatePublicKey.server
     :<|> UpdateData.server
     :<|> Reset.server

--- a/library/Fission/Web/User/VerifyEmail.hs
+++ b/library/Fission/Web/User/VerifyEmail.hs
@@ -1,0 +1,33 @@
+module Fission.Web.User.VerifyEmail
+  ( API
+  , server
+  ) where
+
+import           Fission.Prelude
+import           Servant
+
+import           Fission.Challenge.Types
+import qualified Fission.Challenge.Verifier.Class as Challenge
+
+import           Fission.Web.Error as Web.Err
+import           Fission.Web.Redirect
+
+type API
+  =  Summary "Email verification"
+  :> Description ""
+  :> Capture "Challenge" Challenge
+  :> Get '[JSON] ()
+
+server :: 
+  ( MonadThrow m
+  , MonadLogger m
+  , Challenge.Verifier m
+  )
+ => ServerT API m
+server challenge =
+  Challenge.verify challenge >>= \case
+    Left _ ->
+      Web.Err.throw err404 { errBody = "User does not exist" }
+
+    Right _ -> 
+      redirect "https://fission.codes?verified=true"

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: fission
-version: '2.5.1'
+version: '2.6.0'
 category: API
 author:
   - Brooklyn Zelenka

--- a/server/Fission/Environment/SendInBlue/Types.hs
+++ b/server/Fission/Environment/SendInBlue/Types.hs
@@ -1,0 +1,20 @@
+-- | Configuration for Send In Blue API Requests
+module Fission.Environment.SendInBlue.Types (Environment (..)) where
+
+import           Fission.Prelude
+import qualified Fission.Web.Types              as Web
+import qualified Fission.Email.SendInBlue.Types as SIB
+
+data Environment = Environment
+  { sibApiKey     :: !SIB.ApiKey     -- ^ API Key for SendInBlue
+  , sibUrl        :: !Web.Host       -- ^ Base url for API
+  , sibTemplateId :: !SIB.TemplateId -- ^ Email template ID
+  } deriving (Show, Eq)
+
+instance FromJSON Environment where
+  parseJSON = withObject "SendInBlue.Environment" \obj -> do
+    sibApiKey     <- obj .: "api_key"
+    sibUrl        <- obj .: "base_url"
+    sibTemplateId <- obj .: "template_id"
+
+    return Environment {..}

--- a/server/Fission/Environment/Types.hs
+++ b/server/Fission/Environment/Types.hs
@@ -3,33 +3,36 @@ module Fission.Environment.Types (Environment (..)) where
 
 import Fission.Prelude
 
-import qualified Fission.Environment.Auth.Types    as Auth
-import qualified Fission.Environment.AWS.Types     as AWS
-import qualified Fission.Environment.FFS.Types     as FFS
-import qualified Fission.Environment.IPFS.Types    as IPFS
-import qualified Fission.Environment.Storage.Types as Storage
-import qualified Fission.Environment.Server.Types  as Server
-import qualified Fission.Environment.WebApp.Types  as WebApp
+import qualified Fission.Environment.Auth.Types       as Auth
+import qualified Fission.Environment.AWS.Types        as AWS
+import qualified Fission.Environment.FFS.Types        as FFS
+import qualified Fission.Environment.IPFS.Types       as IPFS
+import qualified Fission.Environment.Storage.Types    as Storage
+import qualified Fission.Environment.Server.Types     as Server
+import qualified Fission.Environment.WebApp.Types     as WebApp
+import qualified Fission.Environment.SendInBlue.Types as SendInBlue
 
 -- | Top-level application configuration. The "knobs" for your app.
 data Environment = Environment
-  { auth    :: !Auth.Environment    -- ^ Auth & ID config
-  , aws     :: !AWS.Environment     -- ^ AWS configuration
-  , ffs     :: !FFS.Environment     -- ^ Fission File System configuration
-  , ipfs    :: !IPFS.Environment    -- ^ IPFS configuration
-  , storage :: !Storage.Environment -- ^ Storage/DB configuration
-  , server  :: !Server.Environment  -- ^ Server configuration
-  , webApp  :: !WebApp.Environment  -- ^ WebApp configuration
+  { auth       :: !Auth.Environment        -- ^ Auth & ID config
+  , aws        :: !AWS.Environment         -- ^ AWS configuration
+  , ffs        :: !FFS.Environment         -- ^ Fission File System configuration
+  , ipfs       :: !IPFS.Environment        -- ^ IPFS configuration
+  , storage    :: !Storage.Environment     -- ^ Storage/DB configuration
+  , server     :: !Server.Environment      -- ^ Server configuration
+  , webApp     :: !WebApp.Environment      -- ^ WebApp configuration
+  , sendInBlue :: !SendInBlue.Environment  -- ^ WebApp configuration
   } deriving Show
 
 instance FromJSON Environment where
   parseJSON = withObject "Environment" \obj -> do
-    auth    <- obj .: "auth"
-    aws     <- obj .: "aws"
-    ffs     <- obj .: "fission_file_system"
-    ipfs    <- obj .: "ipfs"
-    storage <- obj .: "storage"
-    server  <- obj .: "web"
-    webApp  <- obj .: "web_app"
+    auth       <- obj .: "auth"
+    aws        <- obj .: "aws"
+    ffs        <- obj .: "fission_file_system"
+    ipfs       <- obj .: "ipfs"
+    storage    <- obj .: "storage"
+    server     <- obj .: "web"
+    webApp     <- obj .: "web_app"
+    sendInBlue <- obj .: "send_in_blue"
 
     return Environment {..}


### PR DESCRIPTION
## Problem
We need to have verified emails on file so we can help users reset their accounts, receive account / system related email, and optionally subscribe to product updates.

## Solution
- On account creation, create a challenge (32 character string)
- Send a verification email through SendInBlue with a link to `user/email/verify/${challenge}`
- when visited, change a user's status in the DB to **verified**

Closes https://github.com/fission-suite/fission/issues/344