### PR TITLE
File stats

### DIFF
--- a/library/Fission/App.hs
+++ b/library/Fission/App.hs
@@ -7,10 +7,10 @@ module Fission.App
   , CRUD
   ) where
 
-import Fission.App.Retriever (Retriever (..))
-import Fission.App.Creator   (Creator   (..))
-import Fission.App.Modifier  (Modifier  (..))
-import Fission.App.Destroyer (Destroyer (..))
+import Fission.App.Retriever
+import Fission.App.Creator   hiding (Errors)
+import Fission.App.Modifier  hiding (Errors)
+import Fission.App.Destroyer hiding (Errors)
 
 type CRUD m
   = ( Retriever m

--- a/library/Fission/App/Creator/Class.hs
+++ b/library/Fission/App/Creator/Class.hs
@@ -3,10 +3,10 @@ module Fission.App.Creator.Class
   , Errors
   ) where
 
-import           Database.Esqueleto hiding ((<&>))
+import           Servant
 
 import           Network.IPFS.CID.Types
-import           Servant
+import qualified Network.IPFS.Get.Error as IPFS.Stat
 
 import           Fission.Prelude
 import           Fission.Error as Error
@@ -25,21 +25,14 @@ type Errors = OpenUnion
    , ActionNotAuthorized URL
    , NotFound            URL
 
+   , IPFS.Stat.Error
+
    , InvalidURL
    ]
 
 class Monad m => Creator m where
-  create :: UserId -> CID -> UTCTime -> m (Either Errors (AppId, Subdomain))
-
-instance (MonadIO m, App.Domain.Initializer m) => Creator (Transaction m) where
-  create ownerId cid now = do
-    appId <- insert App
-      { appOwnerId    = ownerId
-      , appCid        = cid
-      , appInsertedAt = now
-      , appModifiedAt = now
-      }
-
-    App.Domain.associateDefault ownerId appId now <&> \case
-      Left  err       -> Error.relaxedLeft err
-      Right subdomain -> Right (appId, subdomain)
+  create :: 
+       UserId 
+    -> CID 
+    -> UTCTime 
+    -> m (Either Errors (AppId, Subdomain))

--- a/library/Fission/App/Modifier.hs
+++ b/library/Fission/App/Modifier.hs
@@ -1,3 +1,55 @@
-module Fission.App.Modifier (module Fission.App.Modifier.Class) where
+module Fission.App.Modifier 
+  ( module Fission.App.Modifier.Class
+  , setCidDB
+  ) where
 
-import Fission.App.Modifier.Class
+import           Fission.App.Modifier.Class
+
+import           Database.Persist       as Persist
+
+import           Network.IPFS.CID.Types
+import           Network.IPFS.Bytes.Types
+
+import           Fission.Models
+import           Fission.Ownership
+import           Fission.Prelude        hiding (on)
+import           Fission.URL
+
+import           Fission.Error          as Error
+
+setCidDB ::
+     MonadIO m
+  => UserId 
+  -> URL
+  -> CID
+  -> Bytes
+  -> Bool
+  -> UTCTime
+  -> Transaction m (Either Errors AppId)
+setCidDB userId URL {..} newCID size _copyFlag now = do
+  mayAppDomain <- Persist.selectFirst
+    [ AppDomainDomainName ==. domainName
+    , AppDomainSubdomain  ==. subdomain
+    ] []
+
+  case mayAppDomain of
+    Nothing ->
+      return . Error.openLeft $ NotFound @AppDomain
+
+    Just (Entity _ AppDomain {appDomainAppId = appId}) ->
+      Persist.get appId >>= \case
+        Nothing -> do
+          return . Error.openLeft $ NotFound @App
+
+        Just app ->
+          if isOwnedBy userId app
+            then do
+              update appId 
+                [ AppCid  =. newCID
+                , AppSize =. size
+                ]
+              insert $ SetAppCIDEvent appId newCID size now
+              return $ Right appId
+
+            else
+              return . Error.openLeft $ ActionNotAuthorized @App userId

--- a/library/Fission/Internal/Fixture/User.hs
+++ b/library/Fission/Internal/Fixture/User.hs
@@ -1,6 +1,7 @@
 module Fission.Internal.Fixture.User (user) where
 
 import           Network.IPFS.CID.Types
+import           Network.IPFS.Bytes.Types
 
 import           Fission.Prelude
 import           Fission.Models
@@ -12,8 +13,12 @@ import qualified Fission.Internal.Fixture.Key.Ed25519 as Ed25519
 
 user :: User
 user = User
-  { userUsername = "testUser"
+  { userPublicKey = Just Ed25519.pk
+
+  --
+
   , userEmail    = Just "test@fission.codes"
+  , userUsername = "testUser"
 
   --
 
@@ -23,8 +28,8 @@ user = User
 
   --
 
-  , userPublicKey = Just Ed25519.pk
-  , userDataRoot  = CID "QmW2WQi7j6c7UgJTarActp7tDNikE4B2qXtFCfLPdsgaTQ"
+  , userDataRoot     = CID "QmW2WQi7j6c7UgJTarActp7tDNikE4B2qXtFCfLPdsgaTQ"
+  , userDataRootSize = Bytes 0
 
   --
 

--- a/library/Fission/Internal/Orphanage/Bytes.hs
+++ b/library/Fission/Internal/Orphanage/Bytes.hs
@@ -1,0 +1,26 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Fission.Internal.Orphanage.Bytes () where
+
+import           Fission.Prelude
+
+import           Network.IPFS.Bytes.Types
+
+import           Database.Persist.Class
+import           Database.Persist.Types
+import           Database.Persist.Sql
+
+
+instance PersistField Bytes where
+  toPersistValue (Bytes bytes') = PersistInt64 $ fromIntegral bytes'
+  fromPersistValue = \case
+    PersistInt64 bytes' -> 
+      if bytes' >= 0
+        then Right . Bytes $ fromIntegral bytes'
+        else Left ("Invalid Persistent Bytes: " <> textShow bytes')
+
+    other -> 
+      Left ("Invalid Persistent Bytes: " <> textShow other)
+
+instance PersistFieldSql Bytes where
+  sqlType _pxy = SqlInt64

--- a/library/Fission/Models.hs
+++ b/library/Fission/Models.hs
@@ -15,6 +15,7 @@ import           Data.Swagger
 import           Data.UUID
 
 import           Network.IPFS.CID.Types
+import           Network.IPFS.Bytes.Types
 
 import qualified Fission.Internal.UTF8                as UTF8
 import           Fission.Prelude
@@ -32,6 +33,7 @@ import           Fission.Challenge.Types
 
 import qualified Fission.AWS.Zone.Types               as AWS
 
+import           Fission.Internal.Orphanage.Bytes     ()
 import           Fission.Internal.Orphanage.CID       ()
 import           Fission.Internal.Orphanage.UUID      ()
 
@@ -64,6 +66,7 @@ User
   verified      Bool                 default=false
 
   dataRoot      CID
+  dataRootSize  Bytes
 
   herokuAddOnId HerokuAddOnId Maybe
   secretDigest  SecretDigest  Maybe
@@ -93,10 +96,12 @@ UserChallenge
 ------------
 
 UpdateUserDataRootEvent
-  userId      UserId
-  newDataRoot CID
+  userId          UserId
 
-  insertedAt  UTCTime
+  newDataRoot     CID
+  newDataRootSize Bytes
+
+  insertedAt      UTCTime
 
   deriving Show Eq
 
@@ -134,6 +139,8 @@ App
   ownerId     UserId
   cid         CID
 
+  size        Bytes
+
   insertedAt  UTCTime
   modifiedAt  UTCTime
 
@@ -144,8 +151,11 @@ App
 ------------
 
 CreateAppEvent
+  appId       AppId
   ownerId     UserId
+
   cid         CID
+  size        Bytes
 
   insertedAt  UTCTime
 
@@ -158,8 +168,10 @@ DestroyAppEvent
   deriving Show Eq
 
 SetAppCIDEvent
-  appId  AppId
-  newCID CID
+  appId      AppId
+
+  newCID     CID
+  newCIDSize Bytes
 
   insertedAt UTCTime
 

--- a/library/Fission/User/Creator.hs
+++ b/library/Fission/User/Creator.hs
@@ -1,7 +1,162 @@
 module Fission.User.Creator
   ( module Fission.User.Creator.Class
   , module Fission.User.Creator.Error
+  , createDB
+  , createWithPasswordDB
+  , createWithHerokuDB
   ) where
 
-import Fission.User.Creator.Class
-import Fission.User.Creator.Error
+import           Fission.User.Creator.Class
+import           Fission.User.Creator.Error
+
+import           Data.UUID (UUID)
+import           Database.Esqueleto hiding ((<&>))
+import           Servant
+
+import           Fission.Prelude
+import           Fission.Error as Error
+import           Fission.Models
+
+import           Fission.Key as Key
+
+import qualified Fission.Platform.Heroku.Region.Types  as Heroku
+import qualified Fission.Platform.Heroku.AddOn.Creator as Heroku.AddOn
+
+import qualified Fission.User.Creator.Error as User
+import           Fission.User.Password      as Password
+import           Fission.User.Types
+import qualified Fission.User.Validation    as User
+
+import           Network.IPFS.Bytes.Types
+
+import qualified Fission.App.Content as App.Content
+
+
+createDB ::
+     MonadIO m
+  => Username
+  -> Key.Public
+  -> Email
+  -> UTCTime
+  -> Transaction m (Either Errors UserId)
+createDB username pk email now =
+  User
+    { userPublicKey     = Just pk
+    , userUsername      = username
+    , userEmail         = Just email
+    , userRole          = Regular
+    , userActive        = True
+    , userVerified      = False
+    , userHerokuAddOnId = Nothing
+    , userSecretDigest  = Nothing
+    , userDataRoot      = App.Content.empty
+    , userDataRootSize  = Bytes 0
+    , userInsertedAt    = now
+    , userModifiedAt    = now
+    }
+    |> User.check
+    |> \case
+      Left err ->
+        return $ Error.openLeft err
+
+      Right user ->
+        insertUnique user >>= \case
+          Just userId -> return $ Right userId
+          Nothing -> determineConflict username (Just pk)
+
+
+createWithPasswordDB ::
+     MonadIO m
+  => Username
+  -> Password
+  -> Email
+  -> UTCTime
+  -> Transaction m (Either Errors UserId)
+createWithPasswordDB username password email now =
+  Password.hashPassword password >>= \case
+    Left err ->
+      return $ Error.openLeft err
+
+    Right secretDigest ->
+      User
+        { userPublicKey     = Nothing
+        , userUsername      = username
+        , userEmail         = Just email
+        , userRole          = Regular
+        , userActive        = True
+        , userVerified      = False
+        , userHerokuAddOnId = Nothing
+        , userSecretDigest  = Just secretDigest
+        , userDataRoot      = App.Content.empty
+        , userDataRootSize  = Bytes 0
+        , userInsertedAt    = now
+        , userModifiedAt    = now
+        }
+        |> insertUnique
+        |> bind \case
+          Just userId -> return $ Right userId
+          Nothing -> determineConflict username Nothing
+
+
+createWithHerokuDB ::
+     MonadIO m
+  => UUID
+  -> Heroku.Region
+  -> Username
+  -> Password
+  -> UTCTime
+  -> Transaction m (Either Errors UserId)
+createWithHerokuDB herokuUUID herokuRegion username password now =
+  Heroku.AddOn.create herokuUUID herokuRegion now >>= \case
+    Left err ->
+      return $ Error.openLeft err
+
+    Right herokuAddOnId ->
+      Password.hashPassword password >>= \case
+        Left err ->
+          return $ Error.openLeft err
+
+        Right secretDigest ->
+          User
+            { userPublicKey     = Nothing
+            , userUsername      = username
+            , userEmail         = Nothing
+            , userRole          = Regular
+            , userActive        = True
+            , userVerified      = True
+            , userHerokuAddOnId = Just herokuAddOnId
+            , userSecretDigest  = Just secretDigest
+            , userDataRoot      = App.Content.empty
+            , userDataRootSize  = Bytes 0
+            , userInsertedAt    = now
+            , userModifiedAt    = now
+            }
+            |> insertUnique
+            |> bind \case
+              Just userID -> return $ Right userID
+              Nothing     -> determineConflict username Nothing
+
+determineConflict ::
+  MonadIO m
+  => Username
+  -> Maybe Key.Public
+  -> Transaction m (Either Errors a)
+ 
+determineConflict username Nothing =
+  return . Error.openLeft $ User.ConflictingUsername username
+ 
+determineConflict username (Just pk) = do
+  -- NOTE needs to be updated anlong with DB constraints
+  --      because Postgres doesn't do this out of the box
+
+  conflUN <- getBy (UniqueUsername username) <&> fmap \_ ->
+    User.ConflictingUsername username
+
+  conflPK <- getBy (UniquePublicKey $ Just pk) <&> fmap \_ ->
+    User.ConflictingPublicKey pk
+
+  -- conflEmail TODO
+
+  return case conflUN <|> conflPK of
+    Just err -> Error.openLeft err
+    Nothing  -> Error.openLeft err409 { errBody = "User already exists" }

--- a/library/Fission/User/Modifier.hs
+++ b/library/Fission/User/Modifier.hs
@@ -1,4 +1,60 @@
 module Fission.User.Modifier
-  (module Fission.User.Modifier.Class) where
+  ( updatePasswordDB
+  , updatePublicKeyDB
+  , setDataDB
+  , module Fission.User.Modifier.Class
+  ) where
 
-import Fission.User.Modifier.Class
+import           Fission.User.Modifier.Class
+
+import           Fission.Prelude
+import           Fission.Models
+
+import           Fission.Key           as Key
+import           Fission.Security.Types
+
+import           Database.Persist as Persist
+
+import           Network.IPFS.CID.Types
+import           Network.IPFS.Bytes.Types
+
+
+updatePasswordDB ::
+     MonadIO m
+  => UserId
+  -> SecretDigest
+  -> UTCTime
+  -> Transaction m ()
+updatePasswordDB userId secretDigest now =
+  update userId
+    [ UserSecretDigest =. Just secretDigest
+    , UserModifiedAt   =. now
+    ]
+
+updatePublicKeyDB ::
+     MonadIO m
+  => UserId
+  -> Key.Public
+  -> UTCTime
+  -> Transaction m ()
+updatePublicKeyDB userID pk now =
+  update userID
+    [ UserPublicKey  =. Just pk
+    , UserModifiedAt =. now
+    ]
+  
+setDataDB ::
+     MonadIO m
+  => UserId
+  -> CID
+  -> Bytes
+  -> UTCTime
+  -> Transaction m ()
+setDataDB userId newCID size now = do
+  update userId
+    [ UserDataRoot     =. newCID
+    , UserDataRootSize =. size
+    , UserModifiedAt   =. now
+    ]
+
+  insert_ $ UpdateUserDataRootEvent userId newCID size now

--- a/library/Fission/User/Modifier/Class.hs
+++ b/library/Fission/User/Modifier/Class.hs
@@ -3,9 +3,11 @@ module Fission.User.Modifier.Class
   , Errors
   ) where
 
-import           Database.Persist as Persist
-import           Network.IPFS.CID.Types
 import           Servant.Server
+
+import qualified Network.IPFS.Add.Error as IPFS.Pin -- Pin uses Add errors
+import qualified Network.IPFS.Get.Error as IPFS.Stat -- Stat uses Get errors
+import           Network.IPFS.CID.Types
 
 import           Fission.Error
 import           Fission.Models
@@ -15,11 +17,15 @@ import           Fission.Key           as Key
 import           Fission.URL
 import           Fission.User.Password as Password
 
+
 type Errors = OpenUnion
   '[ NotFound User
   
    , NotFound            URL
    , ActionNotAuthorized URL
+
+   , IPFS.Pin.Error
+   , IPFS.Stat.Error
 
    , ServerError
    , InvalidURL
@@ -43,39 +49,3 @@ class Monad m => Modifier m where
     -> CID
     -> UTCTime
     -> m (Either Errors ())
-
-instance MonadIO m => Modifier (Transaction m) where
-  updatePassword userId password now =
-    Password.hashPassword password >>= \case
-      Left err ->
-        return (Left err)
-
-      Right secretDigest -> do
-        update userId
-          [ UserSecretDigest =. Just secretDigest
-          , UserModifiedAt   =. now
-          ]
-
-        return (Right password)
-
-  updatePublicKey userID pk now = do
-    update userID
-      [ UserPublicKey  =. Just pk
-      , UserModifiedAt =. now
-      ]
-
-    return $ Right pk
-
-  setData userId newCID now = do
-    update userId
-      [ UserDataRoot   =. newCID
-      , UserModifiedAt =. now
-      ]
-
-    insert_ UpdateUserDataRootEvent
-      { updateUserDataRootEventUserId      = userId
-      , updateUserDataRootEventNewDataRoot = newCID
-      , updateUserDataRootEventInsertedAt  = now
-      }
-
-    return ok

--- a/library/Fission/Web.hs
+++ b/library/Fission/Web.hs
@@ -65,8 +65,9 @@ app ::
   , MonadThrow              t
   , Heroku.AddOn.CRUD       t
   , LoosePin.CRUD           t
-  , User.CRUD               t
-  , App.CRUD                t
+  , User.Retriever          t
+  , User.Destroyer          t
+  , App.Retriever           t
   , App.Domain.Retriever    t
   )
   => (forall a . m a -> Handler a)
@@ -104,7 +105,7 @@ server ::
   , LoosePin.CRUD           t
   , User.Retriever          t
   , User.Destroyer          t
-  , App.CRUD                t
+  , App.Retriever           t
   , App.Domain.Retriever    t
   )
   => Web.Host
@@ -134,7 +135,7 @@ bizServer ::
   , LoosePin.CRUD           t
   , User.Retriever          t
   , User.Destroyer          t
-  , App.CRUD                t
+  , App.Retriever           t
   , App.Domain.Retriever    t
   )
   => ServerT Web.API m

--- a/library/Fission/Web/App.hs
+++ b/library/Fission/Web/App.hs
@@ -33,7 +33,7 @@ server ::
   , MonadLogger             m
   , MonadDNSLink            m
   , MonadDB               t m
-  , App.CRUD              t
+  , App.Retriever         t
   , App.Domain.Retriever  t
   )
   => Authorization

--- a/library/Fission/Web/App/Update.hs
+++ b/library/Fission/Web/App/Update.hs
@@ -3,8 +3,9 @@ module Fission.Web.App.Update
   , update
   ) where
 
-import           Network.IPFS.CID.Types
 import           Servant
+
+import           Network.IPFS.CID.Types
 
 import           Fission.Authorization
 import           Fission.Prelude
@@ -13,6 +14,7 @@ import qualified Fission.App            as App
 import           Fission.Web.Error      as Web.Error
 
 import           Fission.URL.Types
+
 
 type API
   =  Summary     "Set app content"
@@ -23,10 +25,10 @@ type API
   :> PatchAccepted '[JSON] NoContent
 
 update ::
-  ( MonadLogger  m
-  , MonadThrow   m
-  , MonadTime    m
-  , App.Modifier m
+  ( MonadLogger     m
+  , MonadThrow      m
+  , MonadTime       m
+  , App.Modifier    m
   )
   => Authorization
   -> ServerT API m

--- a/library/Fission/Web/DNS.hs
+++ b/library/Fission/Web/DNS.hs
@@ -4,18 +4,20 @@ module Fission.Web.DNS
   ) where
 
 import           Database.Esqueleto
-import           Network.IPFS.CID.Types
 import           Servant
+
+import           Network.IPFS.CID.Types
 
 import           Fission.Authorization
 import           Fission.Models
 import           Fission.Prelude
 
 import           Fission.URL                 as URL
-import           Fission.User.Username.Types
 import           Fission.Web.Error           as Web.Err
 
+import           Fission.User.Username.Types
 import qualified Fission.User.Modifier       as User
+
 
 type API
   =  Summary "Set account's DNSLink"

--- a/library/Fission/Web/User/UpdateData.hs
+++ b/library/Fission/Web/User/UpdateData.hs
@@ -4,7 +4,6 @@ module Fission.Web.User.UpdateData
   ) where
 
 import           Database.Esqueleto
-import           Network.IPFS.CID.Types
 import           Servant
 
 import           Fission.Prelude
@@ -13,6 +12,9 @@ import           Fission.Authorization
 import           Fission.Web.Error as Web.Error
 import qualified Fission.User as User
 
+import           Network.IPFS.CID.Types
+
+
 type API
   =  Summary "Update data root"
   :> Description "Set/update currently authenticated user's file system content"
@@ -20,10 +22,10 @@ type API
   :> PatchNoContent '[PlainText, OctetStream, JSON] NoContent
 
 server ::
-  ( MonadLogger   m
-  , MonadThrow    m
-  , MonadTime     m
-  , User.Modifier m
+  ( MonadLogger     m
+  , MonadThrow      m
+  , MonadTime       m
+  , User.Modifier   m
   )
   => Authorization
   -> ServerT API m

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: fission
-version: '2.6.2'
+version: '2.6.3'
 category: API
 author:
   - Brooklyn Zelenka

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -118,7 +118,7 @@ main = do
           logInfo @Text ">>>>>>>>>> Ensuring default user is in DB"
           userId <- User.getByPublicKey serverPK >>= \case
             Just (Entity userId _) -> return userId
-            Nothing -> Web.Error.ensureM $ User.create "fission" serverPK "hello@fission.codes" now
+            Nothing -> Web.Error.ensureM $ User.createDB "fission" serverPK "hello@fission.codes" now
 
           logInfo @Text ">>>>>>>>>> Ensuring default data domain domains is in DB"
           Domain.getByDomainName userRootDomain >>= \case

--- a/stack.yaml
+++ b/stack.yaml
@@ -44,7 +44,7 @@ extra-deps:
 - cryptostore-0.2.1.0
 - happy-1.19.12
 - hspec-wai-json-0.10.1
-- ipfs-1.0.3
+- ipfs-1.1.0
 - lzma-clib-5.2.2
 - raven-haskell-0.1.4.0
 - servant-quickcheck-0.0.7.4

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -40,12 +40,12 @@ packages:
   original:
     hackage: hspec-wai-json-0.10.1
 - completed:
-    hackage: ipfs-1.0.3@sha256:bd7661ff8308fe8f974bd3197891eb6c6ddb03318920e7cf7ffc741518ef928e,5207
+    hackage: ipfs-1.1.0@sha256:dbccc6780c442928ababde4154ad8a7af11f9ce20ab4033f6f1b6dd9dc19a39f,5299
     pantry-tree:
-      size: 3558
-      sha256: ca89800adb0b66c4f38900db3cc42d43b5c068e7d3d722c36b9e79f6baa8fc0c
+      size: 3783
+      sha256: 8f2485bd27a32bf92fe834dbada31657255d9eec6555ed7e17849ceadaa52484
   original:
-    hackage: ipfs-1.0.3
+    hackage: ipfs-1.1.0
 - completed:
     hackage: lzma-clib-5.2.2@sha256:25eb43d5fd8a8ab58380f475b91fb1fa907381f8a81c8d8ba63ba428d97ae0cc,4900
     pantry-tree:


### PR DESCRIPTION
## Problem
We don't currently have stats on the size of a user's storage

## Solution
Track size of user's data root & size of each app in DB
IPLD keeps track of the cumulative size of a node (including the entire subtree), so we can easily query that value each time the user updates their data root or the dnslink for an app