### PR TITLE
Fix DNS.splitRecord tests

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: fission
-version: '2.5.0'
+version: '2.5.1'
 category: API
 author:
   - Brooklyn Zelenka

--- a/test/Test/Fission/DNS.hs
+++ b/test/Test/Fission/DNS.hs
@@ -23,6 +23,8 @@ tests =
           where
             splitCount = NonEmpty.length . DNS.splitRecord
             expectedCount txt = (Text.length txt `div` 252) + 1
+      
+      -- add a serialize/deserialize test once we add `DNS.combineRecords`
 
 newtype SmallText = SmallText Text
   deriving newtype (Show, Eq)

--- a/test/Test/Fission/DNS.hs
+++ b/test/Test/Fission/DNS.hs
@@ -16,8 +16,6 @@ tests =
         itsProp' "length does not change" \(SmallText txt) -> 
           DNS.splitRecord txt `shouldBe` pure txt
 
-      -- @@TODO: Add this test back in once the LargeText Arbitrary instance works
-
       context "over 256 characters" do
         itsProp' "length does not change" \(LargeText txt) -> 
           splitCount txt `shouldBe` expectedCount txt


### PR DESCRIPTION
## Problem
The test for splitting arbitrary large DNS records was hanging

## Solution
Change the arbitrary instance so it doesn't hang (using `Text.replicate`)