### PR TITLE
Default User.verified to false

### DIFF
--- a/library/Fission/Models.hs
+++ b/library/Fission/Models.hs
@@ -61,7 +61,7 @@ User
 
   role          Role
   active        Bool
-  verified      Bool
+  verified      Bool                 default=false
 
   dataRoot      CID
 


### PR DESCRIPTION
## Problem
We have to manually add the `verified` column to the DB since the fields can't be null

## Solution
Add a default value of `false` to the schema so that the DB update can be done automatically