### PR TITLE
Adjust DNS TXT record size

### DIFF
--- a/library/Fission/DNS.hs
+++ b/library/Fission/DNS.hs
@@ -11,14 +11,14 @@ import qualified RIO.List as List
 -- if larger, split into chunks & prefix with a 3-char decimal prefix  & semicolon delimiter ("001;")
 splitRecord :: Text -> NonEmpty Text
 splitRecord txt = 
-  if Text.length txt <= 256
+  if Text.length txt <= txtRecordLimit
     then 
       pure txt
 
     else 
       fromMaybe (pure "") $ nonEmpty records
       where
-        indexed = List.zip [0..] $ Text.chunksOf 252 txt
+        indexed = List.zip [0..] $ Text.chunksOf (txtRecordLimit - 4) txt
         records = joinIndexed <$> indexed
 
 
@@ -27,3 +27,6 @@ joinIndexed (index, txt) =
   paddingIndex <> ";" <> txt
   where
     paddingIndex = Text.takeEnd 3 (Text.replicate 2 "0" <> textDisplay index)
+
+txtRecordLimit :: Int
+txtRecordLimit = 255

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: fission
-version: '2.6.0'
+version: '2.6.1'
 category: API
 author:
   - Brooklyn Zelenka

--- a/test/Test/Fission/DNS.hs
+++ b/test/Test/Fission/DNS.hs
@@ -22,7 +22,7 @@ tests =
 
           where
             splitCount = NonEmpty.length . DNS.splitRecord
-            expectedCount txt = (Text.length txt `div` 252) + 1
+            expectedCount txt = (Text.length txt `div` 251) + 1
       
       -- add a serialize/deserialize test once we add `DNS.combineRecords`
 
@@ -30,10 +30,10 @@ newtype SmallText = SmallText Text
   deriving newtype (Show, Eq)
 
 instance Arbitrary SmallText where
-  arbitrary = SmallText . Text.take 256 <$> arbitrary
+  arbitrary = SmallText . Text.take 255 <$> arbitrary
 
 newtype LargeText = LargeText Text
   deriving newtype (Show, Eq)
 
 instance Arbitrary LargeText where
-  arbitrary = LargeText . Text.replicate 257 <$> arbitrary
+  arbitrary = LargeText . Text.replicate 256 <$> arbitrary


### PR DESCRIPTION
## Problem
TXT records are currently sized to 256 chars, but the max record size in DNS is 255 chars

## Solution
Adjust the size of TXT records to 255 chars