### PR TITLE
Fix setup bug

### DIFF
--- a/library/Fission/CLI/Command/App/Init.hs
+++ b/library/Fission/CLI/Command/App/Init.hs
@@ -105,7 +105,7 @@ appInit App.Init.Options {appDir, buildDir} = do
 
             UTF8.putText " to sync data\n"
 
-            UTF8.putText "💁 It may take DNS time to propogate this initial setup globally. In this case, you can always view your app at "
+            UTF8.putText "💁 It may take DNS time to propagate this initial setup globally. In this case, you can always view your app at "
 
             ANSI.setSGR [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Blue]
             UTF8.putText $ "https://ipfs.runfission.com/ipns/" <> textDisplay appURL' <> "\n"

--- a/library/Fission/CLI/Command/Setup.hs
+++ b/library/Fission/CLI/Command/Setup.hs
@@ -18,6 +18,7 @@ import           Fission.Web.Auth.Token
 import           Fission.Web.Client      as Client
 import qualified Fission.Web.Client.User as User
 
+import qualified Fission.User.Username.Types     as User
 import           Fission.User.Registration.Types
 import           Fission.User.Email.Types
  
@@ -56,13 +57,13 @@ setup ::
   , MonadWebAuth m Token
   , MonadWebAuth m Ed25519.SecretKey
   ) => m ()
-setup = do
-  Key.exists >>= \case
-    True ->
-      CLI.Success.putOk "You are already connected"
+setup =
+  sendRequestM (authClient $ Proxy @User.WhoAmI) >>= \case
+    Right User.Username {username} ->
+      CLI.Success.alreadyLoggedInAs username
 
-    False -> do
-      maybe createAccount upgradeAccount =<< Env.Override.findBasicAuth -- NOTE Deprecated
+    Left _ ->
+      maybe createAccount upgradeAccount =<< Env.Override.findBasicAuth
 
 createAccount ::
   ( MonadIO m

--- a/library/Fission/CLI/Command/Whoami.hs
+++ b/library/Fission/CLI/Command/Whoami.hs
@@ -51,7 +51,7 @@ whoami ::
 whoami = do
   sendRequestM (authClient $ Proxy @User.WhoAmI) >>= \case
     Right User.Username {username} ->
-      CLI.Success.loggedInAs username
+      CLI.Success.currentlyLoggedInAs username
 
     Left err ->
       let

--- a/library/Fission/CLI/Display/Success.hs
+++ b/library/Fission/CLI/Display/Success.hs
@@ -3,7 +3,8 @@ module Fission.CLI.Display.Success
   ( live
   , putOk
   , dnsUpdated
-  , loggedInAs
+  , currentlyLoggedInAs
+  , alreadyLoggedInAs
   ) where
 
 import qualified System.Console.ANSI as ANSI
@@ -30,10 +31,15 @@ dnsUpdated domain = do
   UTF8.putText "📝 DNS updated! Check out your site at: \n"
   UTF8.putText $ "🔗 " <> textDisplay domain  <> "\n"
 
-loggedInAs :: MonadIO m => Text -> m ()
-loggedInAs username = liftIO do
-  UTF8.putText "💻 Currently logged in as: "
+currentlyLoggedInAs :: MonadIO m => Text -> m ()
+currentlyLoggedInAs = loggedInAs "Currently logged in as: "
+
+alreadyLoggedInAs :: MonadIO m => Text -> m ()
+alreadyLoggedInAs = loggedInAs "Already logged in as: "
+
+loggedInAs :: MonadIO m => Text -> Text -> m ()
+loggedInAs msg username = liftIO do
+  UTF8.putText $ "💻 " <> msg
   ANSI.setSGR [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Blue]
   UTF8.putTextLn username 
   ANSI.setSGR [ANSI.Reset]
-

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: fission
-version: '2.6.1'
+version: '2.6.2'
 category: API
 author:
   - Brooklyn Zelenka


### PR DESCRIPTION
## Problem
If setup fails, the key sticks around (even tho it hasn't been linked to an account) and confuses the CLI

## Solution
On setup, check if the local key is associated with an account (`whoami`) instead of just if it exists. Also revamp the message to show the username that you're currently logged in with 