### PR TITLE
Remove debugging printline

### DIFF
--- a/library/Fission/CLI/Config/Base/Types.hs
+++ b/library/Fission/CLI/Config/Base/Types.hs
@@ -161,7 +161,6 @@ instance MonadWebAuth FissionBase Ed25519.SecretKey where
 instance MonadLocalIPFS FissionBase where
   runLocal opts arg = do
     IPFS.BinPath ipfs <- asks ipfsPath
-    logInfo $ ">>>>>>>>>>>>>>>>>" <> Text.pack ipfs
     IPFS.Timeout secs <- asks ipfsTimeout
 
     let opts' = ("--timeout=" <> show secs <> "s") : opts

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: fission
-version: '2.6.3'
+version: '2.6.4'
 category: API
 author:
   - Brooklyn Zelenka


### PR DESCRIPTION
Remove unused line from debugging why IPFS is broken in the CLI on my NixOS system. Thanks to @brainrape for pointing it out!