### PR TITLE
Connect to multiple peers

### DIFF
--- a/library/Fission/CLI/Config/Connected.hs
+++ b/library/Fission/CLI/Config/Connected.hs
@@ -10,6 +10,7 @@ import qualified Crypto.PubKey.Ed25519 as Ed25519
 import           Network.IPFS
 
 import           Fission.Prelude
+import qualified RIO.NonEmpty as NonEmpty
  
 import           Fission.Authorization.ServerDID
 import qualified Fission.Key as Key
@@ -28,7 +29,6 @@ import           Fission.CLI.Environment.Types as Environment
 import qualified Fission.CLI.Environment       as Environment
 import qualified Fission.CLI.IPFS.Connect      as Connect
 
-import qualified RIO.NonEmpty as NonEmpty
 
 -- | Ensure we have a local config file with the appropriate data
 --

--- a/library/Fission/CLI/Config/Connected/Types.hs
+++ b/library/Fission/CLI/Config/Connected/Types.hs
@@ -43,7 +43,7 @@ data ConnectedConfig = ConnectedConfig
   , processCtx   :: !ProcessContext
   , ipfsPath     :: !IPFS.BinPath
   , ipfsTimeout  :: !IPFS.Timeout
-  , peer         :: !IPFS.Peer
+  , peers        :: !(NonEmpty IPFS.Peer)
   , ignoredFiles :: !IPFS.Ignored
   }
 

--- a/library/Fission/CLI/Environment.hs
+++ b/library/Fission/CLI/Environment.hs
@@ -5,7 +5,7 @@ module Fission.CLI.Environment
   , getPath
   , couldNotRead
   , removeConfigFile
-  , getOrRetrievePeer
+  , getOrRetrievePeers
  
   -- * Reexport
 
@@ -94,29 +94,30 @@ removeConfigFile = do
 
 -- | Retrieves a Fission Peer from local config
 --   If not found we retrive from the network and store
-getOrRetrievePeer ::
+getOrRetrievePeers ::
   ( MonadUnliftIO  m
   , MonadLogger    m
   , MonadWebClient m
   )
   => Environment
-  -> m (Maybe IPFS.Peer)
-getOrRetrievePeer Environment {peers = (peer : _)} = do
-  logDebug @Text "Retrieved Peer from .fission.yaml"
-  return $ Just peer
-
-getOrRetrievePeer Environment {peers = []} =
+  -> m [IPFS.Peer]
+getOrRetrievePeers Environment {peers = []} =
   Peers.getPeers >>= \case
     Left err -> do
       logError $ displayShow err
       logDebug @Text "Unable to retrieve peers from the network"
-      return Nothing
+      return []
 
     Right nonEmptyPeers -> do
-      logDebug @Text "Retrieved Peer from API"
       path <- globalEnv
-      Override.writeMerge path $ mempty { peers = NonEmpty.toList nonEmptyPeers }
-      return . Just $ NonEmpty.head nonEmptyPeers
+      let peers = NonEmpty.toList nonEmptyPeers
+      logDebug $ "Retrieved Peers from API, and writing to ~/.fission.yaml: " <> textShow peers
+      Override.writeMerge path $ mempty { peers }
+      return peers
+
+getOrRetrievePeers Environment {peers = peers} = do
+  logDebug $ "Retrieved Peers from .fission.yaml: " <> textShow peers
+  return peers
 
 ignoreDefault :: IPFS.Ignored
 ignoreDefault =

--- a/library/Fission/CLI/Environment.hs
+++ b/library/Fission/CLI/Environment.hs
@@ -115,7 +115,7 @@ getOrRetrievePeers Environment {peers = []} =
       Override.writeMerge path $ mempty { peers }
       return peers
 
-getOrRetrievePeers Environment {peers = peers} = do
+getOrRetrievePeers Environment {peers} = do
   logDebug $ "Retrieved Peers from .fission.yaml: " <> textShow peers
   return peers
 

--- a/library/Fission/CLI/Environment/Override.hs
+++ b/library/Fission/CLI/Environment/Override.hs
@@ -83,7 +83,7 @@ write path env = writeBinaryFileDurable path $ YAML.encode env
 writeMerge :: MonadIO m => FilePath -> Override -> m ()
 writeMerge path newEnv = do
   currentEnv <- decode path
-  writeBinaryFileDurable path $ YAML.encode (currentEnv <> newEnv)
+  write path $ currentEnv <> newEnv
 
 -- | globalEnv environment in users home
 globalEnv :: MonadIO m => m FilePath

--- a/library/Fission/CLI/Environment/Override/Types.hs
+++ b/library/Fission/CLI/Environment/Override/Types.hs
@@ -1,6 +1,5 @@
 module Fission.CLI.Environment.Override.Types (Override (..)) where
 
-import           RIO.List
 import           RIO.Prelude.Types
 
 import           Servant.API
@@ -48,7 +47,7 @@ instance Monoid Override where
 
 instance ToJSON Override where
   toJSON Override {..} = object $ catMaybes
-    [ ("peers"      .=) <$> tailMaybe peers
+    [ ("peers"      .=) <$> pure peers
     , ("app_url"    .=) <$> maybeAppURL
     , ("user_auth"  .=) <$> maybeUserAuth
     , ("ignore"     .=) <$> maybeIgnored

--- a/library/Fission/CLI/IPFS/Connect.hs
+++ b/library/Fission/CLI/IPFS/Connect.hs
@@ -8,6 +8,7 @@ import           Fission.Prelude
 
 import qualified System.Console.ANSI as ANSI
 import qualified RIO.NonEmpty        as NonEmpty
+import           Control.Parallel.Strategies (parMap, rpar)
 
 import           Fission.Web.Client
 import           Fission.Web.Client.Peers as Peers
@@ -19,7 +20,6 @@ import           Fission.CLI.IPFS.Error.Types
 import           Network.IPFS
 import qualified Network.IPFS.Types       as IPFS
 import qualified Network.IPFS.Peer        as IPFS.Peer
-import qualified Network.IPFS.Peer.Error  as IPFS.Peer
 
 
 -- | Connect to the Fission IPFS network with a set amount of retries
@@ -36,7 +36,7 @@ swarmConnectWithRetry _peers (-1) =
   return . Left $ toException UnableToConnect
 
 swarmConnectWithRetry peers tries = do
-  attempts <- connectToPeers $ NonEmpty.toList peers
+  attempts <- sequence $ parMap rpar IPFS.Peer.connect (NonEmpty.toList peers)
   if any isRight attempts
     then do
       logDebug $ "Successfully connected to a node. Full results: " <> textShow attempts
@@ -50,15 +50,6 @@ swarmConnectWithRetry peers tries = do
         Right retryPeers -> do
           UTF8.putText "🛰 Unable to connect to the Fission IPFS peer, trying again...\n"
           swarmConnectWithRetry retryPeers (tries - 1)
-
--- | Connect to a list of peers
-connectToPeers ::
-  ( MonadUnliftIO  m
-  , MonadLocalIPFS m
-  )
-  => [IPFS.Peer]
-  -> m [Either IPFS.Peer.Error ()]
-connectToPeers peers = sequence $ IPFS.Peer.connect <$> peers
 
 -- | Create a could not connect to Fission peer message for the terminal
 couldNotSwarmConnect :: MonadIO m => m ()

--- a/library/Fission/CLI/IPFS/Connect.hs
+++ b/library/Fission/CLI/IPFS/Connect.hs
@@ -7,7 +7,7 @@ module Fission.CLI.IPFS.Connect
 import           Fission.Prelude
 
 import qualified System.Console.ANSI as ANSI
-import           RIO.NonEmpty as NonEmpty hiding ((<|))
+import qualified RIO.NonEmpty        as NonEmpty
 
 import           Fission.Web.Client
 import           Fission.Web.Client.Peers as Peers
@@ -20,7 +20,6 @@ import           Network.IPFS
 import qualified Network.IPFS.Types       as IPFS
 import qualified Network.IPFS.Peer        as IPFS.Peer
 import qualified Network.IPFS.Peer.Error  as IPFS.Peer
-
 
 
 -- | Connect to the Fission IPFS network with a set amount of retries
@@ -39,7 +38,8 @@ swarmConnectWithRetry _peers (-1) =
 swarmConnectWithRetry peers tries = do
   attempts <- connectToPeers $ NonEmpty.toList peers
   if any isRight attempts
-    then 
+    then do
+      logDebug $ "Successfully connected to a node. Full results: " <> textShow attempts
       return ok
 
     else 
@@ -51,6 +51,7 @@ swarmConnectWithRetry peers tries = do
           UTF8.putText "🛰 Unable to connect to the Fission IPFS peer, trying again...\n"
           swarmConnectWithRetry retryPeers (tries - 1)
 
+-- | Connect to a list of peers
 connectToPeers ::
   ( MonadUnliftIO  m
   , MonadLocalIPFS m

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: fission
-version: '2.6.5'
+version: '2.6.6'
 category: API
 author:
   - Brooklyn Zelenka

--- a/package.yaml
+++ b/package.yaml
@@ -123,6 +123,7 @@ dependencies:
   - network-uri
   - optparse-applicative
   - optparse-simple
+  - parallel
   - path-pieces
   - pem
   - persistent


### PR DESCRIPTION
## Problem
The CLI is not connecting to our remote node

## Solution
There are two fixes here:
- make sure that we're writing the entire peerlist from the server to `~/.fission.yaml` (we were just writing the tail for some reason)
- attempt connection to the entire peerlist (we were just attempting to connect to the head of the list)