### PR TITLE
Only print connected error once

### DIFF
--- a/library/Fission/CLI.hs
+++ b/library/Fission/CLI.hs
@@ -38,14 +38,10 @@ cli baseCfg = liftIO do
 
     runConnected_ :: Command FissionConnected input () -> Command.Leaf
     runConnected_ =
-      runWith \actn -> do
-        result <- runConnected baseCfg do
+      runWith \actn ->
+        void $ runConnected baseCfg do
           logDebug @Text "Setting up connected"
           actn
-
-        case result of
-          Right _  -> return ()
-          Left err -> void . runConnected baseCfg $ put' err
 
 summary :: String
 summary = "CLI to interact with Fission services"

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: fission
-version: '2.6.6'
+version: '2.6.7'
 category: API
 author:
   - Brooklyn Zelenka


### PR DESCRIPTION
## Problem
When a user runs a command and is not logged in we print the error twice:
```
🚫 Not logged in yet! Try running `fission setup`
🚫 Not logged in yet! Try running `fission setup`
```
This is base the error message is printed in `runConnected` & we attempt to print the error message again in another `runConnected`

## Solution
Remove the extra `put'`
