### PR TITLE
Error message and spelling updates

### DIFF
--- a/library/Fission/CLI/Command/Setup.hs
+++ b/library/Fission/CLI/Command/Setup.hs
@@ -113,7 +113,7 @@ createAccount = do
 
       in do
         CLI.Error.put err $
-          errMsg <> " Please try again or contact Fission support."
+          errMsg <> " Please try again or contact Fission support https://fission.codes/support."
          
         createAccount
 

--- a/library/Fission/CLI/Command/Whoami.hs
+++ b/library/Fission/CLI/Command/Whoami.hs
@@ -55,7 +55,7 @@ whoami = do
 
     Left err ->
       let
-        commonErrMsg = "Please contact Fission support or delete `~/.ssh/fission` and try again."
+        commonErrMsg = "Please contact Fission support https://fission.codes/support or delete `~/.ssh/fission` and try again."
         specific = case err of
           FailureResponse _ (responseStatusCode -> status) ->
             if | status == status404        -> "We don't recognize your key!"

--- a/library/Fission/CLI/Config/Connected.hs
+++ b/library/Fission/CLI/Config/Connected.hs
@@ -89,7 +89,7 @@ liftConfig BaseConfig {..} = do
 
               in
                 runConnected' connCfg do
-                  logDebug @Text "Connected and attempting user verififcation"
+                  logDebug @Text "Connected and attempting user verification"
                   sendRequestM (authClient $ Proxy @User.Verify) >>= \case
                     Left err -> do
                       CLI.Error.notConnected err


### PR DESCRIPTION
Made a link to https://fission.codes/support consistent in most error messages, and fixed spelling