### PR TITLE
Set DNSLink *after* pinning

### DIFF
--- a/fission-core/package.yaml
+++ b/fission-core/package.yaml
@@ -1,5 +1,5 @@
 name: fission-core
-version: '2.8.0.1'
+version: '2.8.1.0'
 category: API
 author:
   - Brooklyn Zelenka


### PR DESCRIPTION
# Existing Code

1. Update database record
2. Set DNSLink
3. Pin

# Problem

Well, in practice this is completely backwards! We have situations where the files aren’t synced, the user closes their window / stops transfer. Since the DNSLink is already set, there’s no way to get the new data.

# Updated Code

1. Pin
2. Set DNSLink
3. Update database record