### PR TITLE
Stack command and CLI install instructions

### DIFF
--- a/fission-cli/README.md
+++ b/fission-cli/README.md
@@ -33,8 +33,16 @@ cd $FISSION_REPO
 stack install --no-nix fission-cli:fission
 
 # Build only
-stack build --no-nix fission-cli:fission
+stack build --no-nix fission-cli:fission 
 ```
+
+Once you've built the CLI, it is installed in `~/.local/bin/fission`. If you already have an existing fission key in `~/.ssh`, copy it as follows:
+
+```shell
+cp ~/.ssh/fission ~/.config/fission/key/machine_id.ed2551
+```
+
+Now run `fission setup` to install the Fission-controlled IPFS node.
 
 ### Binary Releases
 


### PR DESCRIPTION
The stack command was reversed, also documented copying keys to new config path.

