### PR TITLE
Remove IPFS install instructions

### DIFF
--- a/fission-cli/README.md
+++ b/fission-cli/README.md
@@ -12,10 +12,6 @@ Seamlessly deploy websites and store secure user data
 ### MacOS
 
 ```shell
-# IPFS on MacOS, otherwise https://docs.ipfs.io/introduction/install/
-brew install ipfs
-brew services start ipfs
-
 brew install fission-suite/fission/fission-cli
 ```
 


### PR DESCRIPTION
## Summary

Removing the install / start `ipfs` instructions from the CLI README (now that 2.9.0 has been released)