### PR TITLE
small fix for hinotify

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -2,7 +2,7 @@ let
   sources  = import ./nix/sources.nix;
   pkgs     = import sources.nixpkgs  {};
   unstable = import sources.unstable {};
-  hinotify = if pkgs.stdenv.isDarwin then pkgs.hfsevents else pkgs.haskellPackages.hinotify;
+  hinotify = if pkgs.stdenv.isDarwin then pkgs.haskellPackages.hfsevents else pkgs.haskellPackages.hinotify;
 in
 
 pkgs.mkShell {

--- a/shell.nix
+++ b/shell.nix
@@ -2,7 +2,7 @@ let
   sources  = import ./nix/sources.nix;
   pkgs     = import sources.nixpkgs  {};
   unstable = import sources.unstable {};
-  hinotify = if pkgs.stdenv.isDarwin then pkgs.hfsevents else pkgs.hinotify;
+  hinotify = if pkgs.stdenv.isDarwin then pkgs.hfsevents else pkgs.haskellPackages.hinotify;
 in
 
 pkgs.mkShell {


### PR DESCRIPTION
## Summary

It looks like the `hinotify` package is now part of `haskellPackages` on nixOS - small update for `shell.nix`.