### PR TITLE
clarify buildDir prompt message (#420)

### DIFF
--- a/fission-cli/library/Fission/CLI/Prompt/BuildDir.hs
+++ b/fission-cli/library/Fission/CLI/Prompt/BuildDir.hs
@@ -26,7 +26,7 @@ prompt ::
 prompt relPath = do
   fallback <- colourized [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Blue] do
     fallback <- maybe "." identity <$> guess relPath
-    UTF8.putText $ "👷 Build directory (" <> Text.pack fallback <> "): "
+    UTF8.putText $ "👷 Choose build directory (" <> Text.pack fallback <> "): "
     return fallback
 
   BS.getLine >>= \case

--- a/fission-cli/package.yaml
+++ b/fission-cli/package.yaml
@@ -1,5 +1,5 @@
 name: fission-cli
-version: '2.9.1.0'
+version: '2.9.2.0'
 category: API
 author:
   - Brooklyn Zelenka


### PR DESCRIPTION
Small change to the build dir prompt to clarify (with a verb) as suggested in #420 