### PR TITLE
Update publish watcher for IPFS 0.7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v11
+    - uses: cachix/install-nix-action@v12
       with:
         nix_path: nixpkgs=channel:nixos-unstable
 

--- a/fission-cli/library/Fission/CLI/Handler/App/Publish.hs
+++ b/fission-cli/library/Fission/CLI/Handler/App/Publish.hs
@@ -11,7 +11,6 @@ import           RIO.Directory
 import           Network.HTTP.Types.Status
 
 import           Network.IPFS
-import qualified Network.IPFS.Add                as IPFS
 import           Network.IPFS.CID.Types
 
 import qualified Fission.Internal.UTF8           as UTF8
@@ -105,8 +104,8 @@ handleTreeChanges ::
   -> WatchManager
   -> FilePath -- ^ Build dir
   -> IO StopListening
-handleTreeChanges runner appURL copyFilesFlag timeCache hashCache watchMgr dir =
-  FS.watchTree watchMgr dir (\_ -> True) \_ -> runner do
+handleTreeChanges runner appURL copyFilesFlag timeCache hashCache watchMgr absDir =
+  FS.watchTree watchMgr absDir (\_ -> True) \_ -> runner do
     now     <- getCurrentTime
     oldTime <- readMVar timeCache
 
@@ -114,7 +113,7 @@ handleTreeChanges runner appURL copyFilesFlag timeCache hashCache watchMgr dir =
       void $ swapMVar timeCache now
       threadDelay Time.dohertyMicroSeconds
 
-      IPFS.addDir [] dir >>= \case
+      CLI.IPFS.Add.dir absDir >>= \case
         Left err ->
           CLI.Error.put' err
 

--- a/fission-cli/package.yaml
+++ b/fission-cli/package.yaml
@@ -1,5 +1,5 @@
 name: fission-cli
-version: '2.9.0.1'
+version: '2.9.1.0'
 category: API
 author:
   - Brooklyn Zelenka


### PR DESCRIPTION
## Summary

We updates the IPFS dir add function for publish, but not on the inner watcher loop. In retrospect, capturing this in a closure probably would make sense (but probably needs a `MonadBaseControl` instance, which is coming in the websocket linking PR).

## Closing issues

Closes #418 