### PR TITLE
User register non-interactive

### DIFF
--- a/fission-cli/library/Fission/CLI.hs
+++ b/fission-cli/library/Fission/CLI.hs
@@ -34,6 +34,7 @@ import           Fission.CLI.Parser                             as CLI
 import           Fission.CLI.Parser.Command.Setup.Types         as Setup
 import           Fission.CLI.Parser.Command.Types
 import           Fission.CLI.Parser.Command.User.Types
+import           Fission.CLI.Parser.Command.User.Register.Types as Register
 import           Fission.CLI.Parser.Types                       as Parser
 import           Fission.CLI.Parser.Verbose.Types
 
@@ -108,7 +109,8 @@ interpret baseCfg@Base.Config {ipfsDaemonVar} fissionURL cmd =
 
         User subCmd ->
           case subCmd of
-            Register _ -> void Handler.register
+            Register Register.Options {maybeUsername, maybeEmail} ->
+              Handler.register maybeUsername maybeEmail
             WhoAmI   _ -> Handler.whoami
 
 finalizeDID ::

--- a/fission-cli/library/Fission/CLI.hs
+++ b/fission-cli/library/Fission/CLI.hs
@@ -101,8 +101,8 @@ interpret baseCfg@Base.Config {ipfsDaemonVar} fissionURL cmd =
         Version _ ->
           logInfo $ maybe "unknown" identity (Meta.version =<< Meta.package)
 
-        Setup Setup.Options {forceOS} ->
-          Setup.setup forceOS fissionURL
+        Setup Setup.Options {forceOS, maybeUsername, maybeEmail} ->
+          Setup.setup forceOS fissionURL maybeUsername maybeEmail
 
         App subCmd ->
           App.interpret baseCfg subCmd
@@ -110,7 +110,7 @@ interpret baseCfg@Base.Config {ipfsDaemonVar} fissionURL cmd =
         User subCmd ->
           case subCmd of
             Register Register.Options {maybeUsername, maybeEmail} ->
-              Handler.register maybeUsername maybeEmail
+              void $ Handler.register maybeUsername maybeEmail
             WhoAmI   _ -> Handler.whoami
 
 finalizeDID ::

--- a/fission-cli/library/Fission/CLI/Handler/Setup.hs
+++ b/fission-cli/library/Fission/CLI/Handler/Setup.hs
@@ -28,6 +28,8 @@ import qualified Fission.CLI.Key.Store             as Key
 
 import           Fission.Authorization.ServerDID
 import qualified Fission.CLI.Handler.User.Register as User
+import           Fission.User.Username.Types
+import           Fission.User.Email.Types
 import           Fission.Error
 import           Fission.Web.Auth.Token
 import           Fission.Web.Client                as Client
@@ -60,10 +62,12 @@ setup ::
   )
   => Maybe OS.Supported
   -> BaseUrl
+  -> Maybe Username
+  -> Maybe Email
   -> m ()
-setup maybeOS fissionURL = do
+setup maybeOS fissionURL maybeUsername maybeEmail = do
   Key.create
-  username <- User.register Nothing Nothing
+  username <- User.register maybeUsername maybeEmail
 
   UTF8.putText "Setting default config..."
   Env.init username fissionURL

--- a/fission-cli/library/Fission/CLI/Handler/Setup.hs
+++ b/fission-cli/library/Fission/CLI/Handler/Setup.hs
@@ -63,7 +63,7 @@ setup ::
   -> m ()
 setup maybeOS fissionURL = do
   Key.create
-  username <- User.register
+  username <- User.register Nothing Nothing
 
   UTF8.putText "Setting default config..."
   Env.init username fissionURL

--- a/fission-cli/library/Fission/CLI/Handler/User/Register.hs
+++ b/fission-cli/library/Fission/CLI/Handler/User/Register.hs
@@ -92,7 +92,11 @@ createAccount maybeUsername maybeEmail = do
       ensureM $ mkUsername <$> Prompt.reaskNotEmpty' "Username: "
     Just uname ->
       return uname
-  email    <- Email <$> Prompt.reaskNotEmpty' "Email: "
+  email    <- case maybeEmail of
+    Nothing ->
+      Email <$> Prompt.reaskNotEmpty' "Email: "
+    Just mail ->
+      return mail
 
   let
     form = Registration

--- a/fission-cli/library/Fission/CLI/Handler/User/Register.hs
+++ b/fission-cli/library/Fission/CLI/Handler/User/Register.hs
@@ -51,15 +51,17 @@ register ::
   , IsMember Key.Error   (Errors m)
   , Show (OpenUnion (Errors m))
   )
-  => m Username
-register =
+  => Maybe Username
+  -> Maybe Email
+  -> m Username
+register maybeUsername maybeEmail =
   attempt (sendRequestM . authClient $ Proxy @User.WhoAmI) >>= \case
     Right username -> do
       CLI.Success.alreadyLoggedInAs $ textDisplay username
       return username
 
     Left _ ->
-      createAccount
+      createAccount maybeUsername maybeEmail
 
 createAccount ::
   ( MonadIO          m
@@ -81,9 +83,15 @@ createAccount ::
   , m `Raises` Username.Invalid
   , Show (OpenUnion (Errors m))
   )
-  => m Username
-createAccount = do
-  username <- ensureM $ mkUsername <$> Prompt.reaskNotEmpty' "Username: "
+  => Maybe Username
+  -> Maybe Email
+  -> m Username
+createAccount maybeUsername maybeEmail = do
+  username <- case maybeUsername of
+    Nothing ->
+      ensureM $ mkUsername <$> Prompt.reaskNotEmpty' "Username: "
+    Just uname ->
+      return uname
   email    <- Email <$> Prompt.reaskNotEmpty' "Email: "
 
   let
@@ -129,4 +137,4 @@ createAccount = do
       CLI.Error.put err $
         errMsg <> " Please try again or contact Fission support at https://fission.codes"
 
-      createAccount
+      createAccount maybeUsername maybeEmail

--- a/fission-cli/library/Fission/CLI/Handler/User/Register.hs
+++ b/fission-cli/library/Fission/CLI/Handler/User/Register.hs
@@ -88,11 +88,11 @@ createAccount ::
   -> m Username
 createAccount maybeUsername maybeEmail = do
   username <- case maybeUsername of
-    Nothing -> ensureM $ mkUsername <$> Prompt.reaskNotEmpty' "Username: "
+    Nothing    -> ensureM $ mkUsername <$> Prompt.reaskNotEmpty' "Username: "
     Just uname -> return uname
 
   email <- case maybeEmail of
-    Nothing -> Email <$> Prompt.reaskNotEmpty' "Email: "
+    Nothing   -> Email <$> Prompt.reaskNotEmpty' "Email: "
     Just mail -> return mail
 
   let

--- a/fission-cli/library/Fission/CLI/Handler/User/Register.hs
+++ b/fission-cli/library/Fission/CLI/Handler/User/Register.hs
@@ -88,15 +88,12 @@ createAccount ::
   -> m Username
 createAccount maybeUsername maybeEmail = do
   username <- case maybeUsername of
-    Nothing ->
-      ensureM $ mkUsername <$> Prompt.reaskNotEmpty' "Username: "
-    Just uname ->
-      return uname
-  email    <- case maybeEmail of
-    Nothing ->
-      Email <$> Prompt.reaskNotEmpty' "Email: "
-    Just mail ->
-      return mail
+    Nothing -> ensureM $ mkUsername <$> Prompt.reaskNotEmpty' "Username: "
+    Just uname -> return uname
+
+  email <- case maybeEmail of
+    Nothing -> Email <$> Prompt.reaskNotEmpty' "Email: "
+    Just mail -> return mail
 
   let
     form = Registration

--- a/fission-cli/library/Fission/CLI/Parser/Command/Setup.hs
+++ b/fission-cli/library/Fission/CLI/Parser/Command/Setup.hs
@@ -13,6 +13,8 @@ import           Fission.CLI.Environment.OS.Types       as OS
 
 import           Fission.CLI.Parser.Command.Setup.Types
 import qualified Fission.CLI.Parser.Verbose             as Verbose
+import           Fission.User.Username.Types
+import           Fission.User.Email.Types
 
 parserWithInfo :: ParserInfo Options
 parserWithInfo =
@@ -23,9 +25,44 @@ parserWithInfo =
 
 parser :: Parser Options
 parser = do
-  verboseFlag <- Verbose.parser
-  forceOS     <- osParser
+  verboseFlag   <- Verbose.parser
+  forceOS       <- osParser
+
+  maybeUsername <- option username $ mconcat
+    [ help "The username to register"
+    --------
+    , long "username"
+    , short 'u'
+    --------
+    , value Nothing
+    , metavar "USERNAME"
+    ]
+
+  maybeEmail <- option email $ mconcat
+    [ help "The email address for the account"
+    --------
+    , long "email"
+    , short 'e'
+    -------
+    , value Nothing
+    , metavar "EMAIL"
+    ]
+
   pure Options {..}
+
+username :: ReadM (Maybe Username)
+username = do
+  raw <- str
+  pure case raw of
+    ""   -> Nothing
+    name -> Just name
+
+email :: ReadM (Maybe Email)
+email = do
+  raw <- str
+  pure case raw of
+    ""   -> Nothing
+    mail -> Just mail
 
 osParser :: Parser (Maybe OS.Supported)
 osParser = do

--- a/fission-cli/library/Fission/CLI/Parser/Command/Setup/Types.hs
+++ b/fission-cli/library/Fission/CLI/Parser/Command/Setup/Types.hs
@@ -4,10 +4,14 @@ import           Fission.Prelude
 
 import qualified Fission.CLI.Environment.OS.Types as OS
 import           Fission.CLI.Parser.Verbose.Types
+import           Fission.User.Username.Types
+import           Fission.User.Email.Types
 
 data Options = Options
-  { verboseFlag :: !VerboseFlag
-  , forceOS     :: !(Maybe OS.Supported)
+  { verboseFlag   :: !VerboseFlag
+  , forceOS       :: !(Maybe OS.Supported)
+  , maybeUsername :: !(Maybe Username)
+  , maybeEmail    :: !(Maybe Email)
   } deriving (Show, Eq)
 
 instance Has VerboseFlag Options where

--- a/fission-cli/library/Fission/CLI/Parser/Command/User/Register.hs
+++ b/fission-cli/library/Fission/CLI/Parser/Command/User/Register.hs
@@ -26,6 +26,7 @@ parser = do
   verboseFlag <- Verbose.parser
 
   maybeUsername <- option username $ mconcat
+
     [ help "The username to register"
     --------
     , long "username"
@@ -51,12 +52,12 @@ username :: ReadM (Maybe Username)
 username = do
   raw <- str
   pure case raw of
-    ""       -> Nothing
-    username -> Just username
+    ""   -> Nothing
+    name -> Just name
 
 email :: ReadM (Maybe Email)
 email = do
   raw <- str
   pure case raw of
-    ""    -> Nothing
-    email -> Just email
+    ""   -> Nothing
+    mail -> Just mail

--- a/fission-cli/library/Fission/CLI/Parser/Command/User/Register.hs
+++ b/fission-cli/library/Fission/CLI/Parser/Command/User/Register.hs
@@ -9,6 +9,8 @@ import           Options.Applicative
 
 import           Fission.Prelude
 
+import           Fission.User.Username.Types
+import           Fission.User.Email.Types
 import           Fission.CLI.Parser.Command.User.Register.Types
 import qualified Fission.CLI.Parser.Verbose                     as Verbose
 
@@ -22,4 +24,39 @@ parserWithInfo =
 parser :: Parser Options
 parser = do
   verboseFlag <- Verbose.parser
+
+  maybeUsername <- option username $ mconcat
+    [ help "The username to register"
+    --------
+    , long "username"
+    , short 'u'
+    --------
+    , value Nothing
+    , metavar "USERNAME"
+    ]
+
+  maybeEmail <- option email $ mconcat
+    [ help "The email address for the account"
+    -------
+    , long "email"
+    , short 'e'
+    --------
+    , value Nothing
+    , metavar "EMAIL"
+    ]
+
   pure Options {..}
+
+username :: ReadM (Maybe Username)
+username = do
+  raw <- str
+  pure case raw of
+    ""       -> Nothing
+    username -> Just username
+
+email :: ReadM (Maybe Email)
+email = do
+  raw <- str
+  pure case raw of
+    ""    -> Nothing
+    email -> Just email

--- a/fission-cli/library/Fission/CLI/Parser/Command/User/Register/Types.hs
+++ b/fission-cli/library/Fission/CLI/Parser/Command/User/Register/Types.hs
@@ -3,9 +3,13 @@ module Fission.CLI.Parser.Command.User.Register.Types (Options (..))  where
 import           Fission.Prelude
 
 import           Fission.CLI.Parser.Verbose.Types
+import           Fission.User.Username.Types
+import           Fission.User.Email.Types
 
 data Options = Options
-  { verboseFlag :: !VerboseFlag -- ^ Verbose flag
+  { maybeUsername :: !(Maybe Username)
+  , maybeEmail    :: !(Maybe Email)
+  , verboseFlag :: !VerboseFlag -- ^ Verbose flag
   } deriving (Show, Eq)
 
 instance Has VerboseFlag Options where


### PR DESCRIPTION
## Summary

Adds `--username` and `--email` flags to `fission user register` and `fission setup` so that user registration can be run non-interactively.

## Closing issues
Fixes #416 
