### PR TITLE
New route for resending email verification

### DIFF
--- a/fission-web-api/library/Fission/Web/API/User/Email/Resend/Types.hs
+++ b/fission-web-api/library/Fission/Web/API/User/Email/Resend/Types.hs
@@ -1,0 +1,14 @@
+module Fission.Web.API.User.Email.Resend.Types (Resend) where
+
+import           Fission.Web.API.Prelude
+
+import qualified Fission.Web.API.Auth.Types as Auth
+
+type Resend = "resend" :> Check
+
+type Check
+  =  Summary "Resend verification email"
+  :> Description "Send a verification email to currently authenticated user."
+  --
+  :> Auth.HigherOrder
+  :> PostNoContent

--- a/fission-web-api/library/Fission/Web/API/User/Email/Types.hs
+++ b/fission-web-api/library/Fission/Web/API/User/Email/Types.hs
@@ -4,4 +4,10 @@ import           Fission.Web.API.Prelude
 
 import           Fission.Web.API.User.Email.Verify.Types
 
-type Email = "email" :> Verify
+import           Fission.Web.API.User.Email.Resend.Types
+
+type Email = "email" :> API
+
+type API
+  =    Verify
+  :<|> Resend

--- a/fission-web-server/library/Fission/Web/Server.hs
+++ b/fission-web-server/library/Fission/Web/Server.hs
@@ -71,6 +71,7 @@ app ::
   , MonadEmail                m
   , User.CRUD                 m
   , Challenge.Creator         m
+  , Challenge.Retriever       m
   , Challenge.Verifier        m
   , MonadDB                 t m
   , MonadLogger             t
@@ -110,6 +111,7 @@ server ::
   , MonadEmail                m
   , User.CRUD                 m
   , Challenge.Creator         m
+  , Challenge.Retriever       m
   , Challenge.Verifier        m
   , MonadDB                 t m
   , MonadLogger             t
@@ -141,6 +143,7 @@ bizServer ::
   , MonadEmail                m
   , User.CRUD                 m
   , Challenge.Creator         m
+  , Challenge.Retriever       m
   , Challenge.Verifier        m
   , MonadDB                 t m
   , MonadLogger             t

--- a/fission-web-server/library/Fission/Web/Server/Challenge.hs
+++ b/fission-web-server/library/Fission/Web/Server/Challenge.hs
@@ -1,23 +1,25 @@
 module Fission.Web.Server.Challenge
   ( module Fission.Web.Server.Challenge.Creator.Class
   , module Fission.Web.Server.Challenge.Verifier.Class
+  , module Fission.Web.Server.Challenge.Retriever.Class
   , verificationLink
   ) where
 
-import           Servant                                     hiding (route)
+import           Servant                                      hiding (route)
 
 import           Fission.Prelude
 
 import           Fission.Challenge.Types
 
-import qualified Fission.Web.API.User.Email.Types            as API.User
+import qualified Fission.Web.API.User.Email.Verify.Types      as API.User.Email
 
 import           Fission.Web.Server.Challenge.Creator.Class
 import           Fission.Web.Server.Challenge.Verifier.Class
+import           Fission.Web.Server.Challenge.Retriever.Class
 
-import qualified Fission.Web.Server.Link                     as API
+import qualified Fission.Web.Server.Link                      as API
 
 verificationLink :: Challenge -> Text
 verificationLink challenge = toUrlPiece $ API.mkLink route challenge
   where
-    route = Proxy @("user" :> API.User.Email)
+    route = Proxy @("user" :> "email" :> API.User.Email.Verify)

--- a/fission-web-server/library/Fission/Web/Server/Challenge/Retriever/Class.hs
+++ b/fission-web-server/library/Fission/Web/Server/Challenge/Retriever/Class.hs
@@ -1,0 +1,29 @@
+module Fission.Web.Server.Challenge.Retriever.Class (Retriever (..)) where
+
+import           Database.Persist
+
+import           Fission.Prelude
+
+import           Fission.Challenge.Types
+import           Fission.Error                    as Error
+
+import           Fission.Web.Server.Models
+import           Fission.Web.Server.MonadDB.Types
+
+class Monad m => Retriever m where
+  retrieve :: UserId -> m (Either (NotFound UserChallenge) Challenge)
+
+instance MonadIO m => Retriever (Transaction m) where
+  retrieve userId = do
+    res <- selectFirst [ UserChallengeUserId ==. userId ] []
+    case res of
+      Nothing ->
+        return $ Left NotFound
+
+      Just (Entity _ UserChallenge { userChallengeHash, userChallengeUserId }) ->
+        if userId == userChallengeUserId
+          then do
+            return $ Right userChallengeHash
+
+          else do
+            return $ Left NotFound

--- a/fission-web-server/library/Fission/Web/Server/Email.hs
+++ b/fission-web-server/library/Fission/Web/Server/Email.hs
@@ -1,9 +1,11 @@
 module Fission.Web.Server.Email
   ( module Fission.Web.Server.Email.Class
+  , module Fission.Web.Server.Email.Error
   , module Fission.Web.Server.Email.Types
   , module Fission.Web.Server.Email.SendInBlue.Client
   ) where
 
 import           Fission.Web.Server.Email.Class
+import           Fission.Web.Server.Email.Error
 import           Fission.Web.Server.Email.SendInBlue.Client
 import           Fission.Web.Server.Email.Types

--- a/fission-web-server/library/Fission/Web/Server/Email/Class.hs
+++ b/fission-web-server/library/Fission/Web/Server/Email/Class.hs
@@ -1,13 +1,12 @@
 module Fission.Web.Server.Email.Class (MonadEmail (..)) where
 
-import           Servant.Client
-
 import           Fission.Prelude
 
 import           Fission.Challenge.Types
 
+import           Fission.Web.Server.Email.Error
 import           Fission.Web.Server.Email.Recipient.Types
 import           Fission.Web.Server.Email.SendInBlue.Types as SIB
 
 class Monad m => MonadEmail m where
-  sendVerificationEmail :: Recipient -> Challenge -> m (Either ClientError SIB.Response)
+  sendVerificationEmail :: Recipient -> Challenge -> m (Either CouldNotSend SIB.Response)

--- a/fission-web-server/library/Fission/Web/Server/Email/Error.hs
+++ b/fission-web-server/library/Fission/Web/Server/Email/Error.hs
@@ -1,0 +1,20 @@
+module Fission.Web.Server.Email.Error (CouldNotSend(..)) where
+
+import           Servant.Client
+import           Servant.Server
+
+import           Fission.Prelude
+
+import           Fission.Web.Server.Error.Class
+
+newtype CouldNotSend = CouldNotSend ClientError
+  deriving ( Show
+           , Eq
+           )
+
+instance Display CouldNotSend where
+  display (CouldNotSend _) = "An error occured while trying to send an email"
+
+
+instance ToServerError CouldNotSend where
+  toServerError couldNotSend = err500 { errBody = displayLazyBS couldNotSend }

--- a/fission-web-server/library/Fission/Web/Server/Handler/User.hs
+++ b/fission-web-server/library/Fission/Web/Server/Handler/User.hs
@@ -10,6 +10,7 @@ import           Fission.Web.Server.IPFS.DNSLink.Class          as DNSLink
 import           Fission.Web.Server.WNFS.Class
 
 import qualified Fission.Web.Server.Challenge.Creator.Class     as Challenge
+import qualified Fission.Web.Server.Challenge.Retriever.Class   as Challenge
 import qualified Fission.Web.Server.Challenge.Verifier.Class    as Challenge
 
 import qualified Fission.Web.Server.App.Domain                  as App.Domain
@@ -32,6 +33,7 @@ handler ::
   , User.Creator           m
   , User.Modifier          m
   , Challenge.Creator      m
+  , Challenge.Retriever    m
   , Challenge.Verifier     m
   , MonadWNFS              m
   , MonadTime              m

--- a/fission-web-server/library/Fission/Web/Server/Handler/User.hs
+++ b/fission-web-server/library/Fission/Web/Server/Handler/User.hs
@@ -22,6 +22,7 @@ import qualified Fission.Web.Server.Handler.User.DataRoot       as DataRoot
 import qualified Fission.Web.Server.Handler.User.DID            as DID
 import qualified Fission.Web.Server.Handler.User.ExchangeKey    as ExchangeKey
 import qualified Fission.Web.Server.Handler.User.Password.Reset as Password.Reset
+import qualified Fission.Web.Server.Handler.User.ResendEmail    as ResendEmail
 import qualified Fission.Web.Server.Handler.User.Verify         as Verify
 import qualified Fission.Web.Server.Handler.User.VerifyEmail    as VerifyEmail
 import qualified Fission.Web.Server.Handler.User.WhoAmI         as WhoAmI
@@ -42,7 +43,7 @@ handler ::
 handler = Create.create
      :<|> WhoAmI.handler
      :<|> Verify.handler
-     :<|> VerifyEmail.handler
+     :<|> (VerifyEmail.handler:<|> ResendEmail.handler)
      :<|> DID.handler
      :<|> ExchangeKey.handler
      :<|> DataRoot.handler

--- a/fission-web-server/library/Fission/Web/Server/Handler/User.hs
+++ b/fission-web-server/library/Fission/Web/Server/Handler/User.hs
@@ -21,11 +21,10 @@ import qualified Fission.Web.Server.User.Modifier.Class         as User
 import qualified Fission.Web.Server.Handler.User.Create         as Create
 import qualified Fission.Web.Server.Handler.User.DataRoot       as DataRoot
 import qualified Fission.Web.Server.Handler.User.DID            as DID
+import qualified Fission.Web.Server.Handler.User.Email          as Email
 import qualified Fission.Web.Server.Handler.User.ExchangeKey    as ExchangeKey
 import qualified Fission.Web.Server.Handler.User.Password.Reset as Password.Reset
-import qualified Fission.Web.Server.Handler.User.ResendEmail    as ResendEmail
 import qualified Fission.Web.Server.Handler.User.Verify         as Verify
-import qualified Fission.Web.Server.Handler.User.VerifyEmail    as VerifyEmail
 import qualified Fission.Web.Server.Handler.User.WhoAmI         as WhoAmI
 
 handler ::
@@ -45,7 +44,7 @@ handler ::
 handler = Create.create
      :<|> WhoAmI.handler
      :<|> Verify.handler
-     :<|> (VerifyEmail.handler:<|> ResendEmail.handler)
+     :<|> Email.handler
      :<|> DID.handler
      :<|> ExchangeKey.handler
      :<|> DataRoot.handler

--- a/fission-web-server/library/Fission/Web/Server/Handler/User/Create.hs
+++ b/fission-web-server/library/Fission/Web/Server/Handler/User/Create.hs
@@ -44,13 +44,8 @@ withDID User.Registration {username, email} DID {..} = do
   now       <- currentTime
   userId    <- Web.Err.ensureM $ User.create username publicKey email now
   challenge <- Web.Err.ensureM $ Challenge.create userId
-
-  sendVerificationEmail (Recipient email username) challenge >>= \case
-    Left _ ->
-      Web.Err.throw err500 { errBody = "Could not send verification email" }
-
-    Right _ ->
-      return NoContent
+  Web.Err.ensureM $ sendVerificationEmail (Recipient email username) challenge
+  return NoContent
 
 withPassword ::
   ( MonadDNSLink      m
@@ -68,9 +63,5 @@ withPassword User.Registration {username, password = Just pass, email} = do
   now <- currentTime
   userId <- Web.Err.ensureM $ User.createWithPassword username pass email now
   challenge <- Web.Err.ensureM $ Challenge.create userId
-
-  sendVerificationEmail (Recipient email username) challenge >>= \case
-    Left _ ->
-      Web.Err.throw err500 { errBody = "Could not send verification email" }
-    Right _ ->
-      return ()
+  Web.Err.ensureM $ sendVerificationEmail (Recipient email username) challenge
+  return ()

--- a/fission-web-server/library/Fission/Web/Server/Handler/User/Email.hs
+++ b/fission-web-server/library/Fission/Web/Server/Handler/User/Email.hs
@@ -1,0 +1,26 @@
+module Fission.Web.Server.Handler.User.Email (handler) where
+
+import           Servant
+
+import           Fission.Prelude
+
+import qualified Fission.Web.API.User.Email.Types                     as API
+
+import qualified Fission.Web.Server.Challenge.Retriever.Class   as Challenge
+import qualified Fission.Web.Server.Challenge.Verifier.Class    as Challenge
+
+import           Fission.Web.Server.Email.Class
+
+import qualified Fission.Web.Server.Handler.User.Email.Verify   as Verify
+import qualified Fission.Web.Server.Handler.User.Email.Resend   as Resend
+
+handler ::
+  ( Challenge.Retriever    m
+  , Challenge.Verifier     m
+  , MonadThrow             m
+  , MonadLogger            m
+  , MonadEmail             m
+  )
+  => ServerT API.Email m
+handler = Verify.handler
+     :<|> Resend.handler

--- a/fission-web-server/library/Fission/Web/Server/Handler/User/Email/Resend.hs
+++ b/fission-web-server/library/Fission/Web/Server/Handler/User/Email/Resend.hs
@@ -1,4 +1,4 @@
-module Fission.Web.Server.Handler.User.ResendEmail (handler) where
+module Fission.Web.Server.Handler.User.Email.Resend (handler) where
 
 import           Servant
 

--- a/fission-web-server/library/Fission/Web/Server/Handler/User/Email/Resend.hs
+++ b/fission-web-server/library/Fission/Web/Server/Handler/User/Email/Resend.hs
@@ -27,9 +27,5 @@ handler Authorization { about = Entity _ User { userEmail = Nothing } } =
 
 handler Authorization { about = Entity userId User { userUsername = username, userEmail = Just email } } = do
   challenge <- Web.Err.ensureM $ Challenge.retrieve userId
-
-  sendVerificationEmail (Recipient email username) challenge >>= \case
-    Left _ ->
-      Web.Err.throw err500 { errBody = "Could not send verification email" }
-    Right _ ->
-      return NoContent
+  Web.Err.ensureM $ sendVerificationEmail (Recipient email username) challenge
+  return NoContent

--- a/fission-web-server/library/Fission/Web/Server/Handler/User/Email/Verify.hs
+++ b/fission-web-server/library/Fission/Web/Server/Handler/User/Email/Verify.hs
@@ -1,4 +1,4 @@
-module Fission.Web.Server.Handler.User.VerifyEmail (handler) where
+module Fission.Web.Server.Handler.User.Email.Verify (handler) where
 
 import           Servant
 

--- a/fission-web-server/library/Fission/Web/Server/Handler/User/ResendEmail.hs
+++ b/fission-web-server/library/Fission/Web/Server/Handler/User/ResendEmail.hs
@@ -1,0 +1,35 @@
+module Fission.Web.Server.Handler.User.ResendEmail (handler) where
+
+import           Servant
+
+import           Fission.Prelude
+
+import qualified Fission.Web.API.User.Email.Resend.Types    as API.Email
+
+import           Fission.Web.Server.Authorization.Types
+import qualified Fission.Web.Server.Challenge.Creator.Class as Challenge
+import           Fission.Web.Server.Email.Class
+import           Fission.Web.Server.Email.Types
+import qualified Fission.Web.Server.Error                   as Web.Err
+import           Fission.Web.Server.Models
+
+
+handler ::
+  ( MonadThrow        m
+  , MonadLogger       m
+  , MonadEmail        m
+  , Challenge.Creator m
+  )
+  => ServerT API.Email.Resend m
+
+handler Authorization { about = Entity _ User { userEmail = Nothing } } =
+  Web.Err.throw err422 { errBody = "There is no email associated with the user" }
+
+handler Authorization { about = Entity userId User { userUsername = username, userEmail = Just email } } = do
+  challenge <- Web.Err.ensureM $ Challenge.create userId
+
+  sendVerificationEmail (Recipient email username) challenge >>= \case
+    Left _ ->
+      Web.Err.throw err500 { errBody = "Could not send verification email" }
+    Right _ ->
+      return NoContent

--- a/fission-web-server/library/Fission/Web/Server/Handler/User/ResendEmail.hs
+++ b/fission-web-server/library/Fission/Web/Server/Handler/User/ResendEmail.hs
@@ -4,21 +4,21 @@ import           Servant
 
 import           Fission.Prelude
 
-import qualified Fission.Web.API.User.Email.Resend.Types    as API.Email
+import qualified Fission.Web.API.User.Email.Resend.Types      as API.Email
 
 import           Fission.Web.Server.Authorization.Types
-import qualified Fission.Web.Server.Challenge.Creator.Class as Challenge
+import qualified Fission.Web.Server.Challenge.Retriever.Class as Challenge
 import           Fission.Web.Server.Email.Class
 import           Fission.Web.Server.Email.Types
-import qualified Fission.Web.Server.Error                   as Web.Err
+import qualified Fission.Web.Server.Error                     as Web.Err
 import           Fission.Web.Server.Models
 
 
 handler ::
-  ( MonadThrow        m
-  , MonadLogger       m
-  , MonadEmail        m
-  , Challenge.Creator m
+  ( MonadThrow          m
+  , MonadLogger         m
+  , MonadEmail          m
+  , Challenge.Retriever m
   )
   => ServerT API.Email.Resend m
 
@@ -26,7 +26,7 @@ handler Authorization { about = Entity _ User { userEmail = Nothing } } =
   Web.Err.throw err422 { errBody = "There is no email associated with the user" }
 
 handler Authorization { about = Entity userId User { userUsername = username, userEmail = Just email } } = do
-  challenge <- Web.Err.ensureM $ Challenge.create userId
+  challenge <- Web.Err.ensureM $ Challenge.retrieve userId
 
   sendVerificationEmail (Recipient email username) challenge >>= \case
     Left _ ->

--- a/fission-web-server/library/Fission/Web/Server/Types.hs
+++ b/fission-web-server/library/Fission/Web/Server/Types.hs
@@ -610,6 +610,10 @@ instance Challenge.Creator Server where
   create email =
     runDB $ Challenge.create email
 
+instance Challenge.Retriever Server where
+  retrieve userId =
+    runDB $ Challenge.retrieve userId
+
 instance Challenge.Verifier Server where
   verify challenge =
     runDB $ Challenge.verify challenge

--- a/fission-web-server/library/Fission/Web/Server/Types.hs
+++ b/fission-web-server/library/Fission/Web/Server/Types.hs
@@ -636,7 +636,8 @@ instance MonadEmail Server where
         , params = Email.TemplateOptions verifyUrl name
         }
 
-    liftIO $ runClientM (Email.sendEmail apiKey emailData) env
+    mapLeft Email.CouldNotSend <$>
+      liftIO (runClientM (Email.sendEmail apiKey emailData) env)
 
 pullFromDNS :: [URL] -> Server (Either App.Destroyer.Errors' [URL])
 pullFromDNS urls = do


### PR DESCRIPTION
This is just so that it's up here.

At the moment there's still a bug in here.
When resending a verification email, I create a new challenge. So then there are multiple challenges associated with a user. But verification only `selectFirst`s the challenges.

So two solutions:
* Fetch all challenges when verifying, so `selectAll` or sth like that (possibly less secure)
* Send the same challenge when resending email verification as the one associated.

By the way - is having multiple challenges associated with a user intended? If not, couldn't it become a field of User?

---

First dip into server code yay :tada: 