### PR TITLE
Return non-zero exit codes on failure 

### DIFF
--- a/fission-cli/library/Fission/CLI.hs
+++ b/fission-cli/library/Fission/CLI.hs
@@ -35,8 +35,8 @@ import           Fission.CLI.Release
 import           Fission.CLI.Parser                             as CLI
 import           Fission.CLI.Parser.Command.Setup.Types         as Setup
 import           Fission.CLI.Parser.Command.Types
-import           Fission.CLI.Parser.Command.User.Types
 import           Fission.CLI.Parser.Command.User.Register.Types as Register
+import           Fission.CLI.Parser.Command.User.Types
 import           Fission.CLI.Parser.Types                       as Parser
 import           Fission.CLI.Parser.Verbose.Types
 
@@ -115,7 +115,9 @@ interpret baseCfg@Base.Config {ipfsDaemonVar} fissionURL cmd =
           case subCmd of
             Register Register.Options {maybeUsername, maybeEmail} ->
               void $ Handler.register maybeUsername maybeEmail
-            WhoAmI   _ -> Handler.whoami
+
+            WhoAmI _ ->
+              Handler.whoami
 
 finalizeDID ::
   MonadIO m

--- a/fission-cli/library/Fission/CLI/App.hs
+++ b/fission-cli/library/Fission/CLI/App.hs
@@ -8,6 +8,7 @@ import qualified Data.Yaml                               as YAML
 import           Servant.Client.Core
 
 import qualified Network.DNS                             as DNS
+import qualified Network.IPFS.Process.Error              as IPFS.Process
 import qualified Network.IPFS.Types                      as IPFS
 
 import           Fission.Prelude
@@ -39,6 +40,7 @@ import qualified Fission.CLI.Parser.Config.IPFS          as IPFS
 type Errs =
   '[ SomeException
    , IPFS.UnableToConnect
+   , IPFS.Process.Error
    , ClientError
    , Key.Error
    , NotRegistered
@@ -71,10 +73,8 @@ interpret baseCfg cmd = do
 
     Init App.Init.Options {appDir, buildDir, maySubdomain, ipfsCfg = IPFS.Config {..}} -> do
       let
-        run' ::
-             FissionCLI errs Connected.Config a
-          -> FissionCLI errs Base.Config (Either (OpenUnion errs) a)
-        run' = Connected.run baseCfg timeoutSeconds
+        run' :: FissionCLI errs Connected.Config () -> FissionCLI errs Base.Config ()
+        run' = ensureM . Connected.run baseCfg timeoutSeconds
 
       attempt App.Env.read >>= \case
         Right Env {appURL} -> do
@@ -94,15 +94,16 @@ interpret baseCfg cmd = do
 
     Up App.Up.Options {watch, updateDNS, updateData, filePath, ipfsCfg = IPFS.Config {..}} -> do
       let
-        run' :: MonadIO m => FissionCLI errs Connected.Config a 
-          -> m (Either (OpenUnion errs) a)
-        run' = Connected.run baseCfg timeoutSeconds
+        run' :: FissionCLI errs Connected.Config () -> FissionCLI errs Base.Config ()
+        run' = ensureM . Connected.run baseCfg timeoutSeconds
+
+        runIO :: FissionCLI errs Connected.Config a -> IO ()
+        runIO = void . Connected.run baseCfg timeoutSeconds
 
       attempt App.Env.read >>= \case
         Right Env {appURL} ->
-          run' $ Handler.publish watch run' appURL filePath updateDNS updateData
+          run' $ Handler.publish watch runIO appURL filePath updateDNS updateData
 
-        Left _ -> do 
-          CLI.Error.put (NotFound @URL)
-            "You have not set up an app. Please run `fission app register`"
+        Left _ -> do
+          CLI.Error.put (NotFound @URL) "You have not set up an app. Please run `fission app register`"
           raise $ NotFound @URL

--- a/fission-cli/library/Fission/CLI/Handler/App/Init.hs
+++ b/fission-cli/library/Fission/CLI/Handler/App/Init.hs
@@ -23,10 +23,6 @@ import qualified Fission.CLI.Display.Success     as CLI.Success
 import qualified Fission.CLI.App.Environment     as App.Env
 import qualified Fission.CLI.Prompt.BuildDir     as BuildDir
 
-type Errs = '[
-  ClientError
-]
-
 -- | Sync the current working directory to the server over IPFS
 appInit ::
   ( MonadIO        m
@@ -49,7 +45,7 @@ appInit ::
   => FilePath
   -> Maybe FilePath
   -> Maybe URL.Subdomain
-  -> m (Either (OpenUnion Errs) ())
+  -> m ()
 appInit appDir mayBuildDir' maySubdomain = do
   logDebug @Text "appInit"
 

--- a/fission-cli/library/Fission/CLI/Handler/App/Init.hs
+++ b/fission-cli/library/Fission/CLI/Handler/App/Init.hs
@@ -23,6 +23,10 @@ import qualified Fission.CLI.Display.Success     as CLI.Success
 import qualified Fission.CLI.App.Environment     as App.Env
 import qualified Fission.CLI.Prompt.BuildDir     as BuildDir
 
+type Errs = '[
+  ClientError
+]
+
 -- | Sync the current working directory to the server over IPFS
 appInit ::
   ( MonadIO        m
@@ -45,7 +49,7 @@ appInit ::
   => FilePath
   -> Maybe FilePath
   -> Maybe URL.Subdomain
-  -> m ()
+  -> m (Either (OpenUnion Errs) ())
 appInit appDir mayBuildDir' maySubdomain = do
   logDebug @Text "appInit"
 

--- a/fission-cli/library/Fission/CLI/Handler/App/Publish.hs
+++ b/fission-cli/library/Fission/CLI/Handler/App/Publish.hs
@@ -9,6 +9,7 @@ import           System.FSNotify                 as FS
 import           RIO.Directory
 
 import           Network.HTTP.Types.Status
+import qualified Network.IPFS.Process.Error      as IPFS.Process
 
 import           Network.IPFS
 import           Network.IPFS.CID.Types
@@ -29,18 +30,12 @@ import           Fission.Web.Auth.Token.Types
 import           Fission.Web.Client              as Client
 import           Fission.Web.Client.Error
 
-import           Fission.CLI.Display.Error
 import qualified Fission.CLI.Display.Error       as CLI.Error
 import qualified Fission.CLI.Display.Success     as CLI.Success
 import qualified Fission.CLI.IPFS.Add            as CLI.IPFS.Add
 
 import           Fission.CLI.App.Environment     as App
 import           Fission.CLI.Parser.Watch.Types
-
-type Errs = '[ ClientError
-             , NotFound FilePath
-             , YAML.ParseException
-             ]
 
 -- | Sync the current working directory to the server over IPFS
 publish ::
@@ -56,6 +51,7 @@ publish ::
   , m `Raises` YAML.ParseException
   , m `Raises` NotFound FilePath
   , m `Raises` ClientError
+  , m `Raises` IPFS.Process.Error
   , Show (OpenUnion (Errors m))
   , Contains (Errors m) (Errors m)
   )
@@ -65,8 +61,8 @@ publish ::
   -> FilePath
   -> Bool
   -> Bool
-  -> m (Either (OpenUnion Errs) ())
-publish watchFlag runner appURL appPath _updateDNS updateData = do -- FIXME updateDNS
+  -> m ()
+publish watchFlag runner appURL appPath _updateDNS updateData = -- FIXME updateDNS
   attempt (App.readFrom appPath) >>= \case
     Left err -> do
       CLI.Error.put err "App not set up. Please double check your path, or run `fission app register`"
@@ -76,25 +72,30 @@ publish watchFlag runner appURL appPath _updateDNS updateData = do -- FIXME upda
       absBuildPath <- liftIO $ makeAbsolute buildDir
       logDebug $ "Starting single IPFS add locally of " <> displayShow absBuildPath
 
-      CLI.IPFS.Add.dir absBuildPath >>= putErrOr \cid@(CID hash) -> do
-        req <- App.update appURL cid (Just updateData) <$> Client.attachAuth
+      CLI.IPFS.Add.dir absBuildPath >>= \case
+        Left err -> do
+          CLI.Error.put' err
+          raise err
 
-        retryOnStatus [status502] 100 req >>= \case
-          Left err -> do
-            CLI.Error.put err "Server unable to sync data"
-            raise err
+        Right cid@(CID hash) -> do
+          req <- App.update appURL cid (Just updateData) <$> Client.attachAuth
 
-          Right _ ->
-            case watchFlag of
-              WatchFlag False ->
-                Just $ success appURL
+          retryOnStatus [status502] 100 req >>= \case
+            Left err -> do
+              CLI.Error.put err "Server unable to sync data"
+              raise err
 
-              WatchFlag True ->
-                liftIO $ FS.withManager \watchMgr -> do
-                  hashCache <- newMVar hash
-                  timeCache <- newMVar =<< getCurrentTime
-                  void $ handleTreeChanges runner appURL updateData timeCache hashCache watchMgr absBuildPath
-                  forever . liftIO $ threadDelay 1_000_000 -- Sleep main thread
+            Right _ ->
+              case watchFlag of
+                WatchFlag False ->
+                  success appURL
+
+                WatchFlag True ->
+                  liftIO $ FS.withManager \watchMgr -> do
+                    hashCache <- newMVar hash
+                    timeCache <- newMVar =<< getCurrentTime
+                    void $ handleTreeChanges runner appURL updateData timeCache hashCache watchMgr absBuildPath
+                    forever . liftIO $ threadDelay 1_000_000 -- Sleep main thread
 
 handleTreeChanges ::
   ( MonadIO        m

--- a/fission-cli/library/Fission/CLI/Handler/Setup.hs
+++ b/fission-cli/library/Fission/CLI/Handler/Setup.hs
@@ -59,6 +59,7 @@ setup ::
   , IsMember ClientError (Errors m)
   , IsMember Key.Error (Errors m)
   , Show (OpenUnion (Errors m))
+  , Errors m `Contains` Errors m
   )
   => Maybe OS.Supported
   -> BaseUrl

--- a/fission-cli/library/Fission/CLI/Handler/User/Whoami.hs
+++ b/fission-cli/library/Fission/CLI/Handler/User/Whoami.hs
@@ -41,6 +41,7 @@ whoami ::
   , Show    (OpenUnion (Errors m))
   , Display (OpenUnion (Errors m))
   , IsMember ClientError (Errors m)
+  , Contains (Errors m) (Errors m)
   )
   => m ()
 whoami = do
@@ -67,3 +68,4 @@ whoami = do
               _                 -> "Invalid content type."
 
       UTF8.putText "Please contact Fission support at https://fission.codes or delete `~/.ssh/fission` and try again."
+      raise err

--- a/fission-cli/package.yaml
+++ b/fission-cli/package.yaml
@@ -1,5 +1,5 @@
 name: fission-cli
-version: '2.9.4.1'
+version: '2.9.5.0'
 category: CLI
 author:
   - Brooklyn Zelenka


### PR DESCRIPTION
When a handler errors, make sure the CLI exits with a non-zero exit code. This will help the github action report errors more accurately.

Closes #381 