### PR TITLE
Shortcuts and defaults ("magic" commands)

### DIFF
--- a/fission-cli/library/Fission/CLI.hs
+++ b/fission-cli/library/Fission/CLI.hs
@@ -56,7 +56,7 @@ type Errs
 
 cli :: MonadUnliftIO m => m (Either (OpenUnion Errs) ())
 cli = do
-  Parser.Options {fissionDID, fissionURL, cmd} <- liftIO $ execParser CLI.parserWithInfo
+  Parser.Options {fissionDID, fissionURL, cmd} <- liftIO $ customExecParser (prefs showHelpOnError) CLI.parserWithInfo
 
   let
     VerboseFlag isVerbose = getter cmd

--- a/fission-cli/library/Fission/CLI/Parser/Command.hs
+++ b/fission-cli/library/Fission/CLI/Parser/Command.hs
@@ -4,15 +4,16 @@ import           Options.Applicative
 
 import           Fission.Prelude
 
-import qualified Fission.CLI.Parser.Config.Remote   as Remote
+import qualified Fission.CLI.Parser.Config.Remote       as Remote
 import           Fission.CLI.Parser.Types
 
-import qualified Fission.CLI.Parser.Command.App     as App
-import qualified Fission.CLI.Parser.Command.App.Up  as App.Up
-import qualified Fission.CLI.Parser.Command.Setup   as Setup
-import           Fission.CLI.Parser.Command.Types   as Command
-import qualified Fission.CLI.Parser.Command.User    as User
-import qualified Fission.CLI.Parser.Command.Version as Version
+import qualified Fission.CLI.Parser.Command.App         as App
+import qualified Fission.CLI.Parser.Command.App.Up      as App.Up
+import qualified Fission.CLI.Parser.Command.Setup       as Setup
+import           Fission.CLI.Parser.Command.Types       as Command
+import qualified Fission.CLI.Parser.Command.User        as User
+import qualified Fission.CLI.Parser.Command.User.WhoAmI as User.WhoAmI
+import qualified Fission.CLI.Parser.Command.Version     as Version
 
 parser :: Parser Options
 parser = do
@@ -33,8 +34,9 @@ shortcuts =
   hsubparser $ mconcat
     [ commandGroup "Shortcuts"
     , metavar "SHORTCUT"
-    , command "setup" $ Command.Setup         <$> Setup.parserWithInfo
-    , command "up"    $ Command.App  . App.Up <$> App.Up.parserWithInfo
+    , command "setup"  $ Command.Setup         <$> Setup.parserWithInfo
+    , command "up"     $ Command.App  . App.Up <$> App.Up.parserWithInfo
+    , command "whoami" $ Command.User . User.WhoAmI <$> User.WhoAmI.parserWithInfo
     ]
 
 subCommands :: Parser Command
@@ -45,3 +47,4 @@ subCommands =
     , command "app"  $ fmap Command.App  App.parserWithInfo
     , command "user" $ fmap Command.User User.parserWithInfo
     ]
+


### PR DESCRIPTION
(Result of a pairing session with @expede )

* This adds a new shortcut for `fission whoami` (to `fission user whoami`)
* Also, will show the full `--help` text anytime the parsing fails, including just running `fission` (or `fission not-a-command`, etc)

Re: #386 