### PR TITLE
Allow multiple remote peers

### DIFF
--- a/fission-web-server/env.yaml.example
+++ b/fission-web-server/env.yaml.example
@@ -8,7 +8,8 @@ server:
 ipfs:
   url: http://localhost:5001
   timeout: 3600
-  remotePeer: /dns4/node.runfission.com/tcp/4001/ipfs/QmVLEz2SxoNiFnuyLpbXsH6SvjPTrHNMU88vCQZyhgBzgw
+  remotePeers: 
+    - /dns4/node.runfission.com/tcp/4001/ipfs/QmVLEz2SxoNiFnuyLpbXsH6SvjPTrHNMU88vCQZyhgBzgw
 
 storage:
   stripe_count: 4

--- a/fission-web-server/library/Fission/Web/Server/Config/Types.hs
+++ b/fission-web-server/library/Fission/Web/Server/Config/Types.hs
@@ -36,7 +36,7 @@ data Config = Config
   --
   , ipfsPath          :: IPFS.BinPath
   , ipfsURL           :: IPFS.URL
-  , ipfsRemotePeer    :: IPFS.Peer
+  , ipfsRemotePeers   :: NonEmpty IPFS.Peer
   , ipfsTimeout       :: IPFS.Timeout
   --
   , herokuID          :: Heroku.ID
@@ -78,7 +78,7 @@ instance Show Config where
     --
     , "  ipfsPath          = " <> show ipfsPath
     , "  ipfsURL           = " <> show ipfsURL
-    , "  ipfsRemotePeer    = " <> show ipfsRemotePeer
+    , "  ipfsRemotePeers   = " <> show ipfsRemotePeers
     , "  ipfsTimeout       = " <> show ipfsTimeout
     --
     , "  herokuID          = " <> show herokuID

--- a/fission-web-server/library/Fission/Web/Server/Environment/IPFS/Types.hs
+++ b/fission-web-server/library/Fission/Web/Server/Environment/IPFS/Types.hs
@@ -6,19 +6,19 @@ import qualified Network.IPFS.Types as IPFS
 import           Fission.Prelude
 
 data Environment = Environment
-  { url        :: IPFS.URL     -- ^ IPFS client URL (may be remote)
-  , timeout    :: IPFS.Timeout -- ^ IPFS timeout in seconds
-  , binPath    :: IPFS.BinPath -- ^ Path to local IPFS binary
-  , gateway    :: IPFS.Gateway -- ^ Domain Name of IPFS Gateway
-  , remotePeer :: IPFS.Peer    -- ^ Remote Peer to connect to
+  { url         :: IPFS.URL           -- ^ IPFS client URL (may be remote)
+  , timeout     :: IPFS.Timeout       -- ^ IPFS timeout in seconds
+  , binPath     :: IPFS.BinPath       -- ^ Path to local IPFS binary
+  , gateway     :: IPFS.Gateway       -- ^ Domain Name of IPFS Gateway
+  , remotePeers :: NonEmpty IPFS.Peer -- ^ Remote Peer to connect to
   } deriving Show
 
 instance FromJSON Environment where
   parseJSON = withObject "IPFS.Environment" \obj -> do
-    timeout    <- obj .:? "timeout" .!= 3600
-    binPath    <- obj .:? "binPath" .!= "/usr/local/bin/ipfs"
-    gateway    <- obj .:? "gateway" .!= "ipfs.runfission.com"
-    url        <- obj .:  "url" >>= parseJSON . String
-    remotePeer <- obj .:  "remotePeer"
+    timeout     <- obj .:? "timeout" .!= 3600
+    binPath     <- obj .:? "binPath" .!= "/usr/local/bin/ipfs"
+    gateway     <- obj .:? "gateway" .!= "ipfs.runfission.com"
+    url         <- obj .:  "url" >>= parseJSON . String
+    remotePeers <- obj .:  "remotePeers"
 
     return Environment {..}

--- a/fission-web-server/library/Fission/Web/Server/Internal/Development.hs
+++ b/fission-web-server/library/Fission/Web/Server/Internal/Development.hs
@@ -109,10 +109,10 @@ run logFunc dbPool processCtx httpManager tlsManager action = do
 
     userRootDomain = "userootdomain.net"
 
-    ipfsPath       = "/usr/local/bin/ipfs"
-    ipfsURL        = IPFS.URL $ BaseUrl Http "localhost" 5001 ""
-    ipfsTimeout    = IPFS.Timeout 3600
-    ipfsRemotePeer = IPFS.Peer "/ip4/3.215.160.238/tcp/4001/ipfs/QmVLEz2SxoNiFnuyLpbXsH6SvjPTrHNMU88vCQZyhgBzgw"
+    ipfsPath        = "/usr/local/bin/ipfs"
+    ipfsURL         = IPFS.URL $ BaseUrl Http "localhost" 5001 ""
+    ipfsTimeout     = IPFS.Timeout 3600
+    ipfsRemotePeers = pure $ IPFS.Peer "/ip4/3.215.160.238/tcp/4001/ipfs/QmVLEz2SxoNiFnuyLpbXsH6SvjPTrHNMU88vCQZyhgBzgw"
 
     awsAccessKey   = "SOME_AWS_ACCESS_KEY"
     awsSecretKey   = "SOME_AWS_SECRET_KEY"
@@ -173,10 +173,10 @@ mkConfig dbPool processCtx httpManager tlsManager logFunc linkRelayStoreVar = Co
       , method    = Key
       }
 
-    ipfsPath       = "/usr/local/bin/ipfs"
-    ipfsURL        = IPFS.URL $ BaseUrl Http "localhost" 5001 ""
-    ipfsRemotePeer = IPFS.Peer "/ip4/3.215.160.238/tcp/4001/ipfs/QmVLEz2SxoNiFnuyLpbXsH6SvjPTrHNMU88vCQZyhgBzgw"
-    ipfsTimeout    = IPFS.Timeout 3600
+    ipfsPath        = "/usr/local/bin/ipfs"
+    ipfsURL         = IPFS.URL $ BaseUrl Http "localhost" 5001 ""
+    ipfsRemotePeers = pure $ IPFS.Peer "/ip4/3.215.160.238/tcp/4001/ipfs/QmVLEz2SxoNiFnuyLpbXsH6SvjPTrHNMU88vCQZyhgBzgw"
+    ipfsTimeout     = IPFS.Timeout 3600
 
     baseAppZoneID  = AWS.ZoneID "BASE_APP_ZONE_ID"
     userZoneID     = AWS.ZoneID "USER_ZONE_ID"

--- a/fission-web-server/library/Fission/Web/Server/Internal/Production.hs
+++ b/fission-web-server/library/Fission/Web/Server/Internal/Production.hs
@@ -86,10 +86,10 @@ runInProd action = do
     herokuID       = Hku.ID       . encodeUtf8 $ Hku.id manifest
     herokuPassword = Hku.Password . encodeUtf8 . Hku.password $ Hku.api manifest
 
-    ipfsPath       = env |> ipfs |> binPath
-    ipfsURL        = env |> ipfs |> url
-    ipfsRemotePeer = env |> ipfs |> remotePeer
-    ipfsTimeout    = env |> ipfs |> IPFS.timeout
+    ipfsPath        = env |> ipfs |> binPath
+    ipfsURL         = env |> ipfs |> url
+    ipfsRemotePeers = env |> ipfs |> remotePeers
+    ipfsTimeout     = env |> ipfs |> IPFS.timeout
 
     awsAccessKey   = accessKey
     awsSecretKey   = secretKey

--- a/fission-web-server/library/Fission/Web/Server/Types.hs
+++ b/fission-web-server/library/Fission/Web/Server/Types.hs
@@ -296,7 +296,7 @@ instance MonadDNSLink Server where
       dnsLink    = "dnslink=/ipns/" <> textDisplay followeeURL
 
 instance MonadLinkedIPFS Server where
-  getLinkedPeers = pure <$> asks ipfsRemotePeer
+  getLinkedPeers = asks ipfsRemotePeers
 
 instance IPFS.MonadLocalIPFS Server where
   runLocal opts arg = do
@@ -320,7 +320,7 @@ instance IPFS.MonadLocalIPFS Server where
 
 instance IPFS.MonadRemoteIPFS Server where
   runRemote query = do
-    peerID       <- asks ipfsRemotePeer
+    peerID       <- head <$> asks ipfsRemotePeers
     IPFS.URL url <- asks ipfsURL
     manager      <- asks httpManager
 


### PR DESCRIPTION
## Problem
After upgrading to IPFS Cluster, we now want to return multiple peer IDs, for all the nodes in the cluster.

## Solution
Change `env.yaml` so that it takes a `NonEmpty` list of remote peers. Update `/ipfs/peers` to return this list