### PR TITLE
Make UCANs backward compatible with FLOOFS

### DIFF
--- a/fission-core/library/Fission/Web/Auth/Token/UCAN/Resource/Types.hs
+++ b/fission-core/library/Fission/Web/Auth/Token/UCAN/Resource/Types.hs
@@ -36,9 +36,7 @@ instance FromJSON Resource where
     app    <- fmap FissionApp        <$> obj .:? "app"
     url    <- fmap RegisteredDomain  <$> obj .:? "domain"
 
-    let fs = maybe floofs Just wnfs -- fallback to floofs if UCAN does not include wnfs
-
-    case fs <|> app <|> url of
+    case wnfs <|> floofs <|> app <|> url of
       Just parsed -> return parsed
       Nothing     -> fail "Does not match any known Fission resource"
 

--- a/fission-core/library/Fission/Web/Auth/Token/UCAN/Resource/Types.hs
+++ b/fission-core/library/Fission/Web/Auth/Token/UCAN/Resource/Types.hs
@@ -31,9 +31,12 @@ instance ToJSON Resource where
 
 instance FromJSON Resource where
   parseJSON = withObject "Resource" \obj -> do
-    fs  <- fmap FissionFileSystem <$> obj .:? "wnfs"
-    app <- fmap FissionApp        <$> obj .:? "app"
-    url <- fmap RegisteredDomain  <$> obj .:? "domain"
+    wnfs   <- fmap FissionFileSystem <$> obj .:? "wnfs"
+    floofs <- fmap FissionFileSystem <$> obj .:? "floofs" -- keep around floofs for backward-compatibility
+    app    <- fmap FissionApp        <$> obj .:? "app"
+    url    <- fmap RegisteredDomain  <$> obj .:? "domain"
+
+    let fs = maybe floofs Just wnfs -- fallback to floofs if UCAN does not include wnfs
 
     case fs <|> app <|> url of
       Just parsed -> return parsed


### PR DESCRIPTION
## Problem
We parse UCANs expecting a `wnfs` path, but old versions of the CLI send it as `floofs`

## Solution
Change server parser to accept both