### PR TITLE
Enforce username checks in all tyep classes

### DIFF
--- a/fission-core/library/Fission/User/Username/Types.hs
+++ b/fission-core/library/Fission/User/Username/Types.hs
@@ -97,7 +97,7 @@ instance MimeUnrender PlainText Username where
   mimeUnrender _proxy bs =
     case decodeUtf8' $ Lazy.toStrict bs of
       Left unicodeErr ->
-        Left mconcat
+        Left $ mconcat
           [ "Username "
           , show bs
           , " contains invalid non-unicode character(s): "

--- a/fission-core/library/Fission/User/Username/Types.hs
+++ b/fission-core/library/Fission/User/Username/Types.hs
@@ -36,7 +36,11 @@ mkUsername txt =
     normalized = Text.toLower txt
 
 instance Arbitrary Username where
-  arbitrary = Username <$> arbitrary
+  arbitrary = do
+    txt <- arbitrary
+    case mkUsername $ Text.filter isUsernameChar txt of
+      Left _      -> arbitrary
+      Right uName -> return uName
 
 instance ToParamSchema Username where
   toParamSchema _ = mempty |> type_ ?~ SwaggerString
@@ -47,8 +51,18 @@ instance ToHttpApiData Username where
 instance PersistField Username where
   toPersistValue (Username un) = PersistText un
   fromPersistValue = \case
-    PersistText un -> Right (Username un)
-    other          -> Left ("Invalid Persistent Username: " <> Text.pack (show other))
+    input@(PersistText txt) ->
+      -- NOTE this may break against old DB records, but we really should keep this strict
+      -- I'd rather fail fast so know about it so we can fix it ~expede
+      case mkUsername txt of
+        Left _      -> Left $ errMsg input
+        Right uName -> Right uName
+
+    other ->
+      Left $ errMsg other
+
+    where
+      errMsg input = "Invalid Persistent Username: " <> Text.pack (show input)
 
 instance PersistFieldSql Username where
   sqlType _pxy = SqlString
@@ -57,10 +71,16 @@ instance ToJSON Username where
   toJSON (Username username) = String username
 
 instance FromJSON Username where
-  parseJSON = withText "Username" \txt -> return (Username txt)
+  parseJSON = withText "Username" \txt ->
+    case mkUsername txt of
+      Left _      -> fail . Text.unpack $ "Invalid username: " <> txt
+      Right uName -> return uName
 
 instance FromHttpApiData Username where
-  parseUrlPiece = Right . Username
+  parseUrlPiece txt =
+    case mkUsername txt of
+      Left _err   -> Left $ "Invalid usrename: " <> txt
+      Right uName -> Right uName
 
 instance ToSchema Username where
   declareNamedSchema _ =
@@ -75,7 +95,16 @@ instance MimeRender PlainText Username where
 
 instance MimeUnrender PlainText Username where
   mimeUnrender _proxy bs =
-    bs
-      |> Lazy.toStrict
-      |> decodeUtf8'
-      |> bimap show Username
+    case decodeUtf8' $ Lazy.toStrict bs of
+      Left unicodeErr ->
+        Left mconcat
+          [ "Username "
+          , show bs
+          , " contains invalid non-unicode character(s): "
+          , show unicodeErr
+          ]
+
+      Right txt ->
+        case mkUsername txt  of
+          Left  _err  -> Left . show $ "Invalid username: " <> bs
+          Right uName -> Right uName

--- a/fission-core/library/Fission/User/Username/Validation.hs
+++ b/fission-core/library/Fission/User/Username/Validation.hs
@@ -31,6 +31,11 @@ import           Fission.Prelude
 -- >>> isValid "reCovErY"
 -- False
 --
+-- They can't contain uppercase characters at all
+--
+-- >>> "hElLoWoRlD"
+-- False
+--
 -- Nor are various characters
 --
 -- >>> isValid "under_score"

--- a/fission-core/library/Fission/User/Username/Validation.hs
+++ b/fission-core/library/Fission/User/Username/Validation.hs
@@ -80,8 +80,7 @@ isValid rawUsername =
 
 isUsernameChar :: Char -> Bool
 isUsernameChar c =
-     Char.isAsciiUpper c
-  || Char.isAsciiLower c
+     Char.isAsciiLower c
   || Char.isDigit      c
   || c == '-'
 

--- a/fission-core/library/Fission/User/Username/Validation.hs
+++ b/fission-core/library/Fission/User/Username/Validation.hs
@@ -62,7 +62,7 @@ import           Fission.Prelude
 -- >>> isValid "name&with#chars"
 -- False
 isValid :: Text -> Bool
-isValid rawUsername =
+isValid username =
   all (== True) preds
   where
     preds :: [Bool]
@@ -80,8 +80,6 @@ isValid rawUsername =
 
     startsWithHyphen = Text.isPrefixOf "-" username
     endsWithHyphen   = Text.isSuffixOf "-" username
-
-    username = Text.toLower rawUsername
 
 isUsernameChar :: Char -> Bool
 isUsernameChar c =

--- a/fission-core/library/Fission/User/Username/Validation.hs
+++ b/fission-core/library/Fission/User/Username/Validation.hs
@@ -62,10 +62,13 @@ isValid rawUsername =
   where
     preds :: [Bool]
     preds = [ okChars
+            , not blank
             , not startsWithHyphen
             , not endsWithHyphen
             , not inBlocklist
             ]
+
+    blank = Text.null username
 
     inBlocklist = elem username blocklist
     okChars     = Text.all isUsernameChar username

--- a/fission-core/library/Fission/User/Username/Validation.hs
+++ b/fission-core/library/Fission/User/Username/Validation.hs
@@ -33,7 +33,7 @@ import           Fission.Prelude
 --
 -- They can't contain uppercase characters at all
 --
--- >>> "hElLoWoRlD"
+-- >>> isValid "hElLoWoRlD"
 -- False
 --
 -- Nor are various characters

--- a/fission-web-server/package.yaml
+++ b/fission-web-server/package.yaml
@@ -1,5 +1,5 @@
 name: fission-web-server
-version: '2.10.0.0'
+version: '2.10.1.0'
 category: API
 author:
   - Brooklyn Zelenka


### PR DESCRIPTION
This one is fully on me

![](https://media4.giphy.com/media/3ohzdYJK1wAdPWVk88/giphy.gif)

We're using the "smart constructor" technique where you don't export the base constructor, and instead use a custom function that does checks. It's a really convenient way of enforcing checks at runtime without having to like... write a constructive proof on the incoming data. The checks happen at runtime, and this are wrapped in an `Either`.

The problem here is that inside the module that declares a the data type, you have compete access to the internal field. This is also the module where (most) of your type classes live (needs to be here, or where the class itself if defined).

I created a smart constructor, but failed to update the type classes. So, `FromJSON` was able to bypass the checks and create invalid `Username`s 🤦‍♀️ That's what I get for not enforcing things at the type level, right? 😉 

---

It _is_ nice that the problem is for sure scoped to this module, though 👍 