### PR TITLE
Don't print an "Unable to parse config" warning

### DIFF
--- a/fission-cli/library/Fission/CLI/Release.hs
+++ b/fission-cli/library/Fission/CLI/Release.hs
@@ -8,7 +8,6 @@ import           Fission.Prelude
 
 import           Fission.Error.NotFound.Types
 
-import qualified Fission.CLI.Display.Error    as CLI.Error
 import           Fission.CLI.Display.Text
 import           Fission.CLI.Environment      as Env
 import qualified Fission.CLI.Meta             as Meta
@@ -27,12 +26,11 @@ checkLatestRelease ::
   , MonadEnvironment m
   , m `Raises` YAML.ParseException
   , m `Raises` NotFound FilePath
-  , Show (OpenUnion (Errors m))
   )
   => m ()
 checkLatestRelease = do
   attempt Env.get >>= \case
-    Left  err ->
+    Left  _ ->
       -- Also happens when the CLI isn't setup yet
       logDebug @Text "Unable to parse config"
 

--- a/fission-cli/library/Fission/CLI/Release.hs
+++ b/fission-cli/library/Fission/CLI/Release.hs
@@ -33,7 +33,8 @@ checkLatestRelease ::
 checkLatestRelease = do
   attempt Env.get >>= \case
     Left  err ->
-      CLI.Error.put err "Unable to parse config"
+      -- Also happens when the CLI isn't setup yet
+      logDebug @Text "Unable to parse config"
 
     Right Env {updateChecked} -> do
       now <- currentTime


### PR DESCRIPTION
The CLI used to print an error when fission wasn't set up on the machine yet.

Now the error is converted into a `logDebug`.