### PR TITLE
Allow underscores

### DIFF
--- a/fission-core/library/Fission/URL/Validation.hs
+++ b/fission-core/library/Fission/URL/Validation.hs
@@ -23,7 +23,7 @@ import qualified Fission.Security as Security
 -- True
 --
 -- >>> isValid "under_score"
--- False
+-- True
 --
 -- Blocklisted words are not allowed
 --
@@ -51,9 +51,6 @@ import qualified Fission.Security as Security
 -- >>> isValid "endswith-"
 -- False
 --
--- >>> isValid "endswith_"
--- False
---
 -- >>> isValid "_startswith"
 -- False
 --
@@ -77,8 +74,7 @@ isValid txt =
             , not blank
             , not startsWithHyphen
             , not endsWithHyphen
-            , not endsWithUnderscore
-            , not endsWithUnderscore
+            , not startsWithUnderscore
             , not inBlocklist
             ]
 
@@ -91,7 +87,6 @@ isValid txt =
     endsWithHyphen   = Text.isSuffixOf "-" txt
 
     startsWithUnderscore = Text.isPrefixOf "_" txt
-    endsWithUnderscore   = Text.isSuffixOf "_" txt
 
 isURLChar :: Char -> Bool
 isURLChar c =

--- a/fission-core/library/Fission/URL/Validation.hs
+++ b/fission-core/library/Fission/URL/Validation.hs
@@ -22,6 +22,9 @@ import qualified Fission.Security as Security
 -- >>> isValid "happy-name"
 -- True
 --
+-- >>> isValid "under_score"
+-- False
+--
 -- Blocklisted words are not allowed
 --
 -- >>> isValid "recovery"
@@ -39,9 +42,6 @@ import qualified Fission.Security as Security
 --
 -- Nor are various characters
 --
--- >>> isValid "under_score"
--- False
---
 -- >>> isValid "plus+plus"
 -- False
 --
@@ -49,6 +49,12 @@ import qualified Fission.Security as Security
 -- False
 --
 -- >>> isValid "endswith-"
+-- False
+--
+-- >>> isValid "endswith_"
+-- False
+--
+-- >>> isValid "_startswith"
 -- False
 --
 -- >>> isValid "with.space"
@@ -71,6 +77,8 @@ isValid txt =
             , not blank
             , not startsWithHyphen
             , not endsWithHyphen
+            , not endsWithUnderscore
+            , not endsWithUnderscore
             , not inBlocklist
             ]
 
@@ -82,8 +90,12 @@ isValid txt =
     startsWithHyphen = Text.isPrefixOf "-" txt
     endsWithHyphen   = Text.isSuffixOf "-" txt
 
+    startsWithUnderscore = Text.isPrefixOf "_" txt
+    endsWithUnderscore   = Text.isSuffixOf "_" txt
+
 isURLChar :: Char -> Bool
 isURLChar c =
      Char.isAsciiLower c
   || Char.isDigit      c
   || c == '-'
+  || c == '_'


### PR DESCRIPTION
## Problem
Today, users are restricted to non-underscored usernames and app names (subdomains).

## Solution
- Allow underscores in the validator
- disallow usernames that _start_ with underscores so that we don't have conflicts with `_did`, `_dataroot`, `_dnslink`, etc