### PR TITLE
Fix typo "Fisson" in shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -57,7 +57,7 @@ let
 in
 
 unstable.haskell.lib.buildStackProject {
-  name = "Fisson";
+  name = "Fission";
   nativeBuildInputs = builtins.concatLists [
     deps.common 
     deps.crypto


### PR DESCRIPTION
## Summary
<!-- Summary of the PR -->
This PR fixes a small typo that was bothering me when in a nix-shell
