### PR TITLE
UCAN: alg: "Ed25519" -> alg: "EdDSA"

### DIFF
--- a/fission-cli/package.yaml
+++ b/fission-cli/package.yaml
@@ -1,5 +1,5 @@
 name: fission-cli
-version: '2.10.0.7'
+version: '2.10.1.0'
 category: CLI
 author:
   - Brooklyn Zelenka

--- a/fission-core/library/Fission/Key/Asymmetric/Algorithm/Types.hs
+++ b/fission-core/library/Fission/Key/Asymmetric/Algorithm/Types.hs
@@ -21,8 +21,7 @@ instance Arbitrary Algorithm where
 instance ToJSON Algorithm where
   toJSON = String . \case
     RSA2048 -> "RS256" -- Per the JWT Spec (RFC 7519)
-    Ed25519 -> "Ed25519"
-    -- TODO Ed25519 -> "EdDSA"
+    Ed25519 -> "EdDSA"
 
 instance FromJSON Algorithm where
   parseJSON = withText "JWT.Algorithm" \case

--- a/fission-core/package.yaml
+++ b/fission-core/package.yaml
@@ -1,5 +1,5 @@
 name: fission-core
-version: '3.2.1.0'
+version: '3.2.2.0'
 category: API
 author:
   - Brooklyn Zelenka

--- a/fission-web-server/package.yaml
+++ b/fission-web-server/package.yaml
@@ -1,5 +1,5 @@
 name: fission-web-server
-version: '2.12.1.0'
+version: '2.12.2.0'
 category: API
 author:
   - Brooklyn Zelenka


### PR DESCRIPTION
Use the `alg: EdDSA` in Ed25519 UCANs (per JWT spec). Still accept Ed25519 for historical UCANs.