### PR TITLE
Update ssh-prod command

### DIFF
--- a/nix/commands.nix
+++ b/nix/commands.nix
@@ -126,5 +126,5 @@
         "${ssh} fission@instance.runfission.net";
 
       ssh-prod = cmd "SSH into the production environment"
-        "${ssh} ubuntu@instance.runfission.com";
+        "${ssh} fission@instance.runfission.com";
     }


### PR DESCRIPTION
We updated the prod server, which includes a different username (`ubuntu` -> `fission`). This PR fixes the command to dial into that instance.

# ⚠️ NOTE

You will need to remove `instance.runfission.com` from `~/.ssh/know_hosts` and re-auth it before this change will work