### PR TITLE
Don't create an app on user creation

### DIFF
--- a/fission-web-server/package.yaml
+++ b/fission-web-server/package.yaml
@@ -1,5 +1,5 @@
 name: fission-web-server
-version: '2.13.1.0'
+version: '2.13.2.0'
 category: API
 author:
   - Brooklyn Zelenka

--- a/fission-web-server/package.yaml
+++ b/fission-web-server/package.yaml
@@ -1,5 +1,5 @@
 name: fission-web-server
-version: '2.13.0.0'
+version: '2.13.1.0'
 category: API
 author:
   - Brooklyn Zelenka

--- a/nix/fission-web-server.nix
+++ b/nix/fission-web-server.nix
@@ -11,7 +11,7 @@
     flags = {};
     package = {
       specVersion = "2.2";
-      identifier = { name = "fission-web-server"; version = "2.12.4.0"; };
+      identifier = { name = "fission-web-server"; version = "2.13.1.0"; };
       license = "AGPL-3.0-or-later";
       copyright = "© 2020 Fission Internet Software Services for Open Networks Inc.";
       maintainer = "brooklyn@fission.codes,\ndaniel@fission.codes,\nsteven@fission.codes,\njames@fission.codes";


### PR DESCRIPTION
## Summary

Don't create a "sample" app on account creation.

At the moment this feature is not really that useful and mostly confusing to the users. "I never created an app, why is there one?"

## Test plan (required)

I set up the auth lobby on my pizza instance with this branch's code, created a new account in the lobby and ran this in the console:

![image](https://user-images.githubusercontent.com/1430958/115294734-419e8080-a159-11eb-9bd1-ace832d766d9.png)
