### PR TITLE
Add EKG to server

### DIFF
--- a/fission-web-api/library/Fission/Web/API/Auth/Types.hs
+++ b/fission-web-api/library/Fission/Web/API/Auth/Types.hs
@@ -12,8 +12,8 @@ import           Fission.Web.Auth.Token.Types
 
 import           Fission.Web.API.Prelude
 
-import           Fission.Web.API.Auth.UCAN.Types
 import qualified Fission.Web.API.Heroku.Auth.Types as Heroku
+import           Fission.Web.API.Auth.UCAN.Types
 
 type Auth = "auth" :> UCAN
 

--- a/fission-web-api/library/Fission/Web/API/Auth/Types.hs
+++ b/fission-web-api/library/Fission/Web/API/Auth/Types.hs
@@ -12,8 +12,8 @@ import           Fission.Web.Auth.Token.Types
 
 import           Fission.Web.API.Prelude
 
-import qualified Fission.Web.API.Heroku.Auth.Types as Heroku
 import           Fission.Web.API.Auth.UCAN.Types
+import qualified Fission.Web.API.Heroku.Auth.Types as Heroku
 
 type Auth = "auth" :> UCAN
 

--- a/fission-web-server/library/Fission/Web/Server/Environment/Server/Types.hs
+++ b/fission-web-server/library/Fission/Web/Server/Environment/Server/Types.hs
@@ -15,6 +15,7 @@ data Environment = Environment
   , environment  :: Remote           -- ^ Which remote this server is acting as / env
   , port         :: Web.Port         -- ^ Web app's port
   , isTLS        :: Bool             -- ^ Run over TLS
+  , useEKG       :: Bool             -- ^ Run with EKG
   , pretty       :: Bool             -- ^ Pretty-print requests
   , sentryDSN    :: Maybe Sentry.DSN -- ^ Sentry DSN key
   , serverZoneID :: AWS.ZoneID       -- ^ Hosted Zone of this server (runfission.com at time of writing)
@@ -25,6 +26,7 @@ instance FromJSON Environment where
     sentryDSN    <- obj .:? "sentry_dsn"
     pretty       <- obj .:? "pretty" .!= False
     isTLS        <- obj .:? "tls"    .!= True
+    useEKG       <- obj .:? "ekg"    .!= True
     port         <- obj .:? "port"   .!= Web.Port if isTLS then 443 else 80
     host         <- obj .:  "host"
     environment  <- obj .:  "environment"

--- a/fission-web-server/library/Fission/Web/Server/Environment/Server/Types.hs
+++ b/fission-web-server/library/Fission/Web/Server/Environment/Server/Types.hs
@@ -26,7 +26,7 @@ instance FromJSON Environment where
     sentryDSN    <- obj .:? "sentry_dsn"
     pretty       <- obj .:? "pretty" .!= False
     isTLS        <- obj .:? "tls"    .!= True
-    useEKG       <- obj .:? "ekg"    .!= True
+    useEKG       <- obj .:? "ekg"    .!= False
     port         <- obj .:? "port"   .!= Web.Port if isTLS then 443 else 80
     host         <- obj .:  "host"
     environment  <- obj .:  "environment"

--- a/fission-web-server/library/Fission/Web/Server/Internal/Orphanage/HigherOrder.hs
+++ b/fission-web-server/library/Fission/Web/Server/Internal/Orphanage/HigherOrder.hs
@@ -5,6 +5,7 @@ module Fission.Web.Server.Internal.Orphanage.HigherOrder () where
 import           Data.Swagger
 
 import           Servant
+import           Servant.Ekg
 import           Servant.Swagger
 
 import           Fission.Prelude
@@ -16,3 +17,7 @@ instance HasSwagger api => HasSwagger (HigherOrder :> api) where
   toSwagger _ = Proxy @api
              |> toSwagger
              |> securityDefinitions .~ SecurityDefinitions [("Fission Auth", fissionSecurity)]
+
+instance HasEndpoint sub => HasEndpoint (AuthProtect "higher-order" :> sub) where
+  getEndpoint        _ = getEndpoint        $ Proxy @sub
+  enumerateEndpoints _ = enumerateEndpoints $ Proxy @sub

--- a/fission-web-server/library/Fission/Web/Server/Internal/Orphanage/RegisterDid.hs
+++ b/fission-web-server/library/Fission/Web/Server/Internal/Orphanage/RegisterDid.hs
@@ -5,6 +5,7 @@ module Fission.Web.Server.Internal.Orphanage.RegisterDid () where
 import           Data.Swagger
 
 import           Servant
+import           Servant.Ekg
 import           Servant.Swagger
 
 import           Fission.Prelude
@@ -17,3 +18,7 @@ instance HasSwagger api => HasSwagger (RegisterDID :> api) where
     Proxy @api
       |> toSwagger
       |> securityDefinitions .~ SecurityDefinitions [("Fission Auth", fissionSecurity)]
+
+instance HasEndpoint sub => HasEndpoint (RegisterDID :> sub) where
+  getEndpoint        _ = getEndpoint        $ Proxy @sub
+  enumerateEndpoints _ = enumerateEndpoints $ Proxy @sub

--- a/fission-web-server/library/Fission/Web/Server/Internal/Orphanage/WebSocket.hs
+++ b/fission-web-server/library/Fission/Web/Server/Internal/Orphanage/WebSocket.hs
@@ -5,9 +5,14 @@ module Fission.Web.Server.Internal.Orphanage.WebSocket () where
 import           Data.Swagger
 
 import           Servant.API.WebSocket
+import           Servant.Ekg
 import           Servant.Swagger
 
 import           Fission.Prelude
 
 instance HasSwagger WebSocket where
   toSwagger _ =  mempty |> schemes ?~ [Wss]
+
+instance HasEndpoint WebSocket where
+  getEndpoint      _ _ = Just $ APIEndpoint [] "WebSocket"
+  enumerateEndpoints _ =       [APIEndpoint [] "WebSocket"]

--- a/fission-web-server/library/Fission/Web/Server/Internal/Production.hs
+++ b/fission-web-server/library/Fission/Web/Server/Internal/Production.hs
@@ -168,7 +168,7 @@ runInProd overrideVerbose action = do
     ekg <- liftIO . EKG.monitorEndpoints api =<< EKG.newStore
 
     let
-      condEKG      = if True then ekg else identity
+      condEKG      = if useEKG then ekg      else identity
       condDebug    = if pretty then identity else logStdoutDev
       middleware   = condEKG . condDebug
 

--- a/fission-web-server/package.yaml
+++ b/fission-web-server/package.yaml
@@ -153,6 +153,7 @@ dependencies:
   - hostname
 
   ## Web ##
+  - ekg-core
   - http-client
   - http-client-tls
   - http-media
@@ -164,6 +165,7 @@ dependencies:
   - servant-auth-swagger
   - servant-client
   - servant-client-core
+  - servant-ekg
   - servant-server
   - servant-swagger
   - servant-swagger-ui-redoc

--- a/fission-web-server/package.yaml
+++ b/fission-web-server/package.yaml
@@ -152,20 +152,23 @@ dependencies:
   - amazonka-route53
   - hostname
 
-  ## Web ##
+  ## Monitoring
   - ekg-core
+  - ekg-statsd
+  - raven-haskell
+  - servant-ekg
+
+  ## Web ##
   - http-client
   - http-client-tls
   - http-media
   - http-types
   - ipfs
-  - raven-haskell
   - servant
   - servant-auth-server
   - servant-auth-swagger
   - servant-client
   - servant-client-core
-  - servant-ekg
   - servant-server
   - servant-swagger
   - servant-swagger-ui-redoc

--- a/fission-web-server/package.yaml
+++ b/fission-web-server/package.yaml
@@ -1,5 +1,5 @@
 name: fission-web-server
-version: '2.15.0.0'
+version: '2.15.0.1'
 category: API
 author:
   - Brooklyn Zelenka

--- a/shell.nix
+++ b/shell.nix
@@ -18,6 +18,8 @@ let
   server-port = 10235;
 
   deps = {
+    bench = [pkgs.wrk2];
+
     common = [ 
       pkgs.gnumake
       unstable.niv

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@ extra-deps:
   - lzma-clib-5.2.2
   - raven-haskell-0.1.4.0
   - rescue-0.4.2.1
-  - servant-ekg-0.3.1
+  - servant-ekg-0.3.1 # Needs the allow-newer
   - servant-multipart-client-0.12.1
   - servant-swagger-ui-redoc-0.3.4.1.22.3
   - servant-websockets-2.0.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-18.0
+resolver: lts-18.5
 
 packages:
   - fission-cli

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,5 @@
 resolver: lts-18.5
+allow-newer: true
 
 packages:
   - fission-cli

--- a/stack.yaml
+++ b/stack.yaml
@@ -16,6 +16,8 @@ extra-deps:
   - ipfs-1.3.1
   - lzma-clib-5.2.2
   - raven-haskell-0.1.4.0
+  - rescue-0.4.2.1
+  - servant-ekg-0.3.1
   - servant-multipart-client-0.12.1
   - servant-swagger-ui-redoc-0.3.4.1.22.3
   - servant-websockets-2.0.0

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -61,6 +61,20 @@ packages:
   original:
     hackage: raven-haskell-0.1.4.0
 - completed:
+    hackage: rescue-0.4.2.1@sha256:53256f87722af6f91e9e4ed18741c5e2515a0432ae7e94b16e3edf73931ec0c3,5025
+    pantry-tree:
+      size: 1963
+      sha256: 74b6dfd972089dba05241803a450e808348c5db6dc204810cc01161266c72194
+  original:
+    hackage: rescue-0.4.2.1
+- completed:
+    hackage: servant-ekg-0.3.1@sha256:19bd9dc3943983da8e79d6f607614c68faea4054fb889d508c8a2b67b6bdd448,2203
+    pantry-tree:
+      size: 552
+      sha256: 432766c31fdcd06fd2102d4d0ac63217c880d80d3bef4ad64b5b2ed95f8af355
+  original:
+    hackage: servant-ekg-0.3.1
+- completed:
     hackage: servant-multipart-client-0.12.1@sha256:d043063e2f33eab86840f87c4bdb16eb3fe4a5847a0b118e4f4265cf3ba4c9b3,1892
     pantry-tree:
       size: 400
@@ -111,7 +125,7 @@ packages:
     hackage: http-link-header-1.0.3.1
 snapshots:
 - completed:
-    size: 585393
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/0.yaml
-    sha256: c632012da648385b9fa3c29f4e0afd56ead299f1c5528ee789058be410e883c0
-  original: lts-18.0
+    size: 585817
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/5.yaml
+    sha256: 22d24d0dacad9c1450b9a174c28d203f9bb482a2a8da9710a2f2a9f4afee2887
+  original: lts-18.5


### PR DESCRIPTION
[EKG is a tool for metrics](http://maxgabriel.github.io/ekg-yesod/). There's a bunch of packages for integrating with ElasticSearch and whatnot. I figured that it may be good for us to have some of these stats even crudely in panels for checking the production environment to find bottlenecks.

Use case: as we're bumping up the number of IPFS client HTTP connections originating from the server, I'd like to see if it's actually unblocking that previous bottleneck that Philipp seemed to run into with a large number of concurrent IPFS-related requests.

As with any instrumentation, this adds some overhead to our server. According to the docs, it's generally in the range of 200-600µs.