### PR TITLE
Bump Stack to 2.7.1

### DIFF
--- a/nix/commands.nix
+++ b/nix/commands.nix
@@ -20,7 +20,6 @@
           pkgs.writeScriptBin name ''
             #!${bash}
             echo "⚙️  Running ${name}..."
-            unset STACK_IN_NIX_SHELL
             ${script}
           '';
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da7f4c4842520167f65c20ad75ecdbd14e27ae91",
-        "sha256": "0vdq6lkc1sqj85x8r8idpck3igjns8ix57fqf1r5pm4k0qhy7p2m",
+        "rev": "accb1763abada1afb6517b67206460de8a70bd3e",
+        "sha256": "0nb2n7kmmlv5260k07rmbhp607k2nlcgpya3x4j0cii1c1nhzwf4",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/da7f4c4842520167f65c20ad75ecdbd14e27ae91.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/accb1763abada1afb6517b67206460de8a70bd3e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {
@@ -17,10 +17,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "af958e8057f345ee1aca714c1247ef3ba1c15f5e",
-        "sha256": "1qjavxabbrsh73yck5dcq8jggvh3r2jkbr6b5nlz5d9yrqm9255n",
+        "rev": "94080ae8286024820c570a2a24ed7c36d7ad04a9",
+        "sha256": "0wlk52zwlrq727x3z1vg9d9qq4zw62ab5jzg4068iqb6hyb0cr0w",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/af958e8057f345ee1aca714c1247ef3ba1c15f5e.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/94080ae8286024820c570a2a24ed7c36d7ad04a9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "91b77fe6942fe999b1efbe906dc98024d1917c0d",
-        "sha256": "041l46ccllbf9b94jxahw64zsjxs1368y4m5a5q2h41w82jjmdk1",
+        "rev": "7974217f94c2970026c411d9234dbb47e93a7306",
+        "sha256": "0hh91i4zk74g1lrk11x62kdnvn5435nw1jnhkyk3yw4ck4f2qv8d",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/91b77fe6942fe999b1efbe906dc98024d1917c0d.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/7974217f94c2970026c411d9234dbb47e93a7306.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "unstable": {
@@ -41,10 +41,10 @@
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "54c1e44240d8a527a8f4892608c4bce5440c3ecb",
-        "sha256": "0v2yymmz62gi69zqisggmk2iqdwfar5m2x9zymxzdif6gg912jqs",
+        "rev": "c58b97674b12d238d9d21e8ab9ee9d7a6b81ae8f",
+        "sha256": "1f56wh0z2hhk3x64m0iv7fj1irrpgb38v3agqcd0jibi13nmg89l",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/54c1e44240d8a527a8f4892608c4bce5440c3ecb.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/c58b97674b12d238d9d21e8ab9ee9d7a6b81ae8f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,5 @@
 resolver: lts-17.11
 
-  # allow-newer: true
-
 packages:
   - fission-cli
   - fission-core

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
-resolver: lts-17.10
+resolver: lts-17.11
 
-allow-newer: true
+  # allow-newer: true
 
 packages:
   - fission-cli
@@ -27,6 +27,6 @@ ghc-options:
   "$everything": -haddock
 
 nix:
-  enable:     false
+  enable:     true
   pure:       true
   shell-file: shell.nix

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -90,7 +90,7 @@ packages:
     hackage: unliftio-core-0.1.2.0
 snapshots:
 - completed:
-    size: 567241
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/10.yaml
-    sha256: 321b3b9f0c7f76994b39e0dabafdc76478274b4ff74cc5e43d410897a335ad3b
-  original: lts-17.10
+    size: 567672
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/11.yaml
+    sha256: 03181cdbeb671eb605bbcf6f285bea4d094b6ac7433a0e14a9f1dd54ad995938
+  original: lts-17.11


### PR DESCRIPTION
@walkah rejoice for `In Nix shell but reExecL is False` is no more!

In other words, we don't _need_ to use all of the custom commands from inside Nix now. You can just `stack build`.

* Bump Stack to 2.7.1 (updated Nix packages in general)
* Enable Nix integration by default

---

NOTE: remember that you'll need to `lorri shell` to get the updated Stack