### PR TITLE
CLI: add --with-key option to setup

### DIFF
--- a/fission-cli/library/Fission/CLI.hs
+++ b/fission-cli/library/Fission/CLI.hs
@@ -100,8 +100,8 @@ interpret baseCfg@Base.Config {ipfsDaemonVar} cmd =
         Version _ -> do
           logUser $ Version.showVersion CLI.version
 
-        Setup Setup.Options {forceOS, maybeUsername, maybeEmail} ->
-          Setup.setup forceOS maybeUsername maybeEmail
+        Setup Setup.Options {forceOS, maybeUsername, maybeEmail, maybeKeyFile} ->
+          Setup.setup forceOS maybeUsername maybeEmail maybeKeyFile
 
         App subCmd ->
           App.interpret baseCfg subCmd

--- a/fission-cli/library/Fission/CLI/Handler/Setup.hs
+++ b/fission-cli/library/Fission/CLI/Handler/Setup.hs
@@ -1,47 +1,53 @@
 module Fission.CLI.Handler.Setup (setup) where
 
 import           Network.IPFS
-import qualified Network.IPFS.Process.Error        as IPFS.Process
+import qualified Network.IPFS.Process.Error                  as IPFS.Process
+import           RIO.FilePath
 
-import           Network.DNS                       as DNS
+import           Network.DNS                                 as DNS
 import           Servant.Client
 
 import           Fission.Prelude
 
 import           Fission.Error
-import           Fission.Key.Error                 as Key
+import           Fission.Key                                 as Key
 
 import           Fission.User.DID.Types
 import           Fission.User.Email.Types
-import qualified Fission.User.Username.Error       as Username
+import qualified Fission.User.Username.Error                 as Username
 import           Fission.User.Username.Types
 
-import           Fission.Web.Client                as Client
+import           Fission.Web.Auth.Token.JWT.Types
+import           Fission.Web.Client                          as Client
 import           Fission.Web.Client.HTTP.Class
+import qualified Fission.Web.Client.User                     as User
 
-import qualified Fission.CLI.Environment.OS        as OS
-import           Fission.CLI.Environment.Types
+import           Fission.CLI.Display.Error                   as CLI.Error
+
+import           Fission.CLI.Environment                     as Env
+import qualified Fission.CLI.Environment.OS                  as OS
 import           Fission.CLI.Remote
 
-import qualified Fission.CLI.User                  as User
+import qualified Fission.CLI.User                            as User
 
-import qualified Fission.CLI.Display.Success       as Display
-import qualified Fission.CLI.IPFS.Executable       as Executable
-import qualified Fission.CLI.Prompt                as Prompt
+import qualified Fission.CLI.Display.Success                 as Display
+import qualified Fission.CLI.IPFS.Executable                 as Executable
+import qualified Fission.CLI.Prompt                          as Prompt
 
-import           Fission.CLI.Key.Store             as Key
-import           Fission.CLI.Key.Store             as Key.Store
+import           Fission.CLI.Key.Store                       as Key
+import           Fission.CLI.Key.Store                       as Key.Store
 
-import qualified Fission.CLI.Handler.User.Login    as Login
-import qualified Fission.CLI.Handler.User.Login    as User
-import qualified Fission.CLI.Handler.User.Register as User
+import qualified Fission.CLI.Handler.User.Login              as Login
+import qualified Fission.CLI.Handler.User.Login              as User
+import qualified Fission.CLI.Handler.User.Register           as User
+
+import qualified Fission.CLI.WebNative.FileSystem.Auth.Store as WNFS
 
 setup ::
   ( MonadIO          m
   , MonadLocalIPFS   m
   , MonadManagedHTTP m
   , MonadWebAuth     m (SecretKey SigningKey)
-
   , m `Raises` AlreadyExists DID
   , m `Raises` AlreadyExists Env
   , m `Raises` ClientError
@@ -62,8 +68,9 @@ setup ::
   => Maybe OS.Supported
   -> Maybe Username
   -> Maybe Email
+  -> Maybe FilePath
   -> m ()
-setup maybeOS maybeUsername maybeEmail = do
+setup maybeOS maybeUsername maybeEmail maybeKeyFile = do
   logUser @Text "🌱 Setting up environment"
   Executable.place maybeOS
 
@@ -72,19 +79,33 @@ setup maybeOS maybeUsername maybeEmail = do
       Display.putOk "Done! You're all ready to go 🚀"
 
     Right () -> do
-      logUser @Text "🔑 Creating keys"
-      void . Key.Store.create $ Proxy @SigningKey
+      logUser @Text "🔑 Setting up keys"
       void . Key.Store.create $ Proxy @ExchangeKey
+      case maybeKeyFile of
+        Just keyFile -> do
+          logDebug $ "🔑 Got a Keyfile: " <> keyFile
+          Key.Store.fromFile (Proxy @SigningKey) keyFile
+          attempt (sendAuthedRequest RootCredential User.whoami) >>= \case
+            Left err -> do
+              CLI.Error.put err "Invalid key file provided."
+              raise err
+            Right username -> do
+              baseURL <- getRemoteBaseUrl
+              signingPK  <- Key.Store.fetchPublic (Proxy @SigningKey)
+              _ <- WNFS.create (DID Key $ Ed25519PublicKey signingPK) "/"
+              Env.init username baseURL Nothing
+              Display.putOk $ "Done! Welcome to Fission, " <> textDisplay username <> " ✨"
+        Nothing -> do
+          void . Key.Store.create $ Proxy @SigningKey
+          username <- do
+            Prompt.reaskYN "🏠 Do you have an existing account?" >>= \case
+              False ->
+                User.register maybeUsername maybeEmail
 
-      username <- do
-        Prompt.reaskYN "🏠 Do you have an existing account?" >>= \case
-          False ->
-            User.register maybeUsername maybeEmail
+              True -> do
+                logUser @Text "🔗 Please open auth.fission.codes on a signed-in device"
+                signingSK <- Key.Store.fetch $ Proxy @SigningKey
+                rootURL   <- getRemoteBaseUrl
+                Login.consume signingSK rootURL {baseUrlPath = "/user/link"} maybeUsername
 
-          True -> do
-            logUser @Text "🔗 Please open auth.fission.codes on a signed-in device"
-            signingSK <- Key.Store.fetch $ Proxy @SigningKey
-            rootURL   <- getRemoteBaseUrl
-            Login.consume signingSK rootURL {baseUrlPath = "/user/link"} maybeUsername
-
-      Display.putOk $ "Done! Welcome to Fission, " <> textDisplay username <> " ✨"
+          Display.putOk $ "Done! Welcome to Fission, " <> textDisplay username <> " ✨"

--- a/fission-cli/library/Fission/CLI/Parser/Command/Setup.hs
+++ b/fission-cli/library/Fission/CLI/Parser/Command/Setup.hs
@@ -46,6 +46,16 @@ parser = do
     , metavar "EMAIL"
     ]
 
+  maybeKeyFile <- option keyfile $ mconcat
+    [ help "A root keyfile to import"
+    -------
+    , long "with-key"
+    , short 'k'
+    -------
+    , value Nothing
+    , metavar "KEYFILE"
+    ]
+
   pure Options {..}
 
 username :: ReadM (Maybe Username)
@@ -61,6 +71,14 @@ email = do
   pure case raw of
     ""   -> Nothing
     mail -> Just mail
+
+keyfile :: ReadM (Maybe FilePath)
+keyfile = do
+  raw <- str
+  pure case raw of
+    ""   -> Nothing
+    path -> Just path
+
 
 osParser :: Parser (Maybe OS.Supported)
 osParser = do

--- a/fission-cli/library/Fission/CLI/Parser/Command/Setup/Types.hs
+++ b/fission-cli/library/Fission/CLI/Parser/Command/Setup/Types.hs
@@ -10,4 +10,5 @@ data Options = Options
   { forceOS       :: Maybe OS.Supported
   , maybeUsername :: Maybe Username
   , maybeEmail    :: Maybe Email
+  , maybeKeyFile  :: Maybe FilePath
   } deriving (Show, Eq)

--- a/fission-cli/package.yaml
+++ b/fission-cli/package.yaml
@@ -1,5 +1,5 @@
 name: fission-cli
-version: '2.13.0.0'
+version: '2.14.0.0'
 category: CLI
 author:
   - Brooklyn Zelenka


### PR DESCRIPTION
This PR adds a `--with-key` option to `fission setup` that allows the CLI to bootstrap with a given key file (i.e. `machine_id.ed25519`). This is useful if you just back up your key file to move to a new machine or restore. It is also required to upgrade the https://github.com/fission-suite/publish-action to the latest CLI version.

This is related to #496 but an interim step, mostly to clean up the publish action in a backwards compatible way (right now the publish action takes advantage of old CLI versions that would check if there was a machine key in place already). 

Example: 
<img width="591" alt="Screen Shot 2021-05-18 at 9 38 40 AM" src="https://user-images.githubusercontent.com/15350/118663341-ba2b4800-b7be-11eb-9689-3f259fab7ebc.png">

And if the key file is bad or wrong (e.g. my key from staging used against production):
<img width="674" alt="Screen Shot 2021-05-18 at 9 39 05 AM" src="https://user-images.githubusercontent.com/15350/118663577-ca432780-b7be-11eb-991f-736a80c32a1c.png">

