### PR TITLE
Fix how setup runs ipfs init

### DIFF
--- a/fission-cli/library/Fission/CLI/IPFS/Configure.hs
+++ b/fission-cli/library/Fission/CLI/IPFS/Configure.hs
@@ -7,30 +7,24 @@ module Fission.CLI.IPFS.Configure
   , enableRelay
   ) where
 
-import qualified RIO.ByteString.Lazy          as Lazy
+import qualified RIO.ByteString.Lazy        as Lazy
 
-import           Network.IPFS.Local.Class     as IPFS
-import qualified Network.IPFS.Process.Error   as IPFS
-import qualified Network.IPFS.Types           as IPFS
+import           Network.IPFS.Local.Class   as IPFS
+import qualified Network.IPFS.Process.Error as IPFS
 
 import           Turtle
 
 import           Fission.Prelude
 
-import           Fission.CLI.Environment      hiding (init)
-import           Fission.CLI.Environment.Path
 
-init :: (MonadIO m, MonadEnvironment m) => m ExitCode
+init ::
+  ( MonadLocalIPFS m
+  , MonadRaise     m
+  , m `Raises` IPFS.Error
+  )
+  => m IPFS.RawMessage
 init = do
-  IPFS.BinPath ipfsPath <- globalIPFSBin
-  ipfsRepo              <- globalIPFSRepo
-   -- Needs to be run manually because it's a prerequesite for the daemon
-  runProcess . fromString $ intercalate " "
-    [ "IPFS_PATH=" <> ipfsRepo
-    , ipfsPath
-    , "init"
-    , "&> /dev/null"
-    ]
+  ensureM $ IPFS.runLocal ["init"] ""
 
 setBootstrap :: forall m . MonadLocalIPFS m => m (Either IPFS.Error ())
 setBootstrap =

--- a/fission-cli/library/Fission/CLI/IPFS/Executable.hs
+++ b/fission-cli/library/Fission/CLI/IPFS/Executable.hs
@@ -6,7 +6,7 @@ module Fission.CLI.IPFS.Executable
 import qualified RIO.ByteString.Lazy           as Lazy
 import qualified RIO.Text                      as Text
 
-import qualified Turtle                        as Turtle
+import qualified Turtle
 
 import           Network.IPFS
 import qualified Network.IPFS.File.Types       as File
@@ -70,10 +70,10 @@ place' host = do
 
   logUser @Text "🎛️  Configuring managed IPFS"
 
-  IPFS.Config.init
-  void $ IPFS.Config.enableRelay
+  void IPFS.Config.init
+  void IPFS.Config.enableRelay
 
-  void $ IPFS.Config.setApiAddress
-  void $ IPFS.Config.setBootstrap
-  void $ IPFS.Config.setGatewayAddress
-  void $ IPFS.Config.setSwarmAddresses
+  void IPFS.Config.setApiAddress
+  void IPFS.Config.setBootstrap
+  void IPFS.Config.setGatewayAddress
+  void IPFS.Config.setSwarmAddresses

--- a/fission-cli/package.yaml
+++ b/fission-cli/package.yaml
@@ -1,5 +1,5 @@
 name: fission-cli
-version: '2.14.0.0'
+version: '2.14.1.0'
 category: CLI
 author:
   - Brooklyn Zelenka


### PR DESCRIPTION
# Summary

This PR changes how we run `ipfs init` during setup. We already have a nice `IPFS.runLocal` wrapper that cleanly handles stdout / stderr and checks exit codes for the IPFS process. We use it everywhere *except* when calling `ipfs init`. On some platforms (sometimes?) ipfs init would not complete before the subsequent commands tried to run - resulting in error messages (ipfs repo locked). 


Fixes #499 
