### PR TITLE
Remove STACK_IN_NIX_SHELL from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,3 @@ Web server, database, 3rd party integrations
 # Building
 
 Fission is built inside of a pure Nix shell via the [Stack integration](https://docs.haskellstack.org/en/stable/nix_integration/). This means that you _should_ only need to type `stack build` to do a complete build of all packages.
-
-Unfortunately, the Stack integration doesn't play well with [`lorri`](https://github.com/target/lorri). If you've run `lorri` recently, you will either need to build with `--no-nix` or unset the `STACK_IN_NIX_SHELL` environment variable.
-
-```bash
-# bash or zsh
-unset STACK_IN_NIX_SHELL
-```
-
-```fish
-set -e STACK_IN_NIX_SHELL
-```


### PR DESCRIPTION
This was fixed in Stack 2.7. You can just `stack build` now, and it defaults to building in a pure Nix environment. You can still pass it `--no-nix` for non-Nix builds.