### PR TITLE
Hotfix: CLI watch flag causes hang

### DIFF
--- a/fission-cli/library/Fission/CLI/Handler/App/Publish.hs
+++ b/fission-cli/library/Fission/CLI/Handler/App/Publish.hs
@@ -120,10 +120,7 @@ publish
               when open  do
                 liftIO . void . openBrowser $ ipfsGateway <> "/" <> show appURL
 
-              logDebug @Text ">>>>>>>>>>>> BEFORE WATCHING"
-
               when watching do
-                logDebug @Text ">>>>>>>>>>>> STARTED WATCHING"
                 liftIO $ FS.withManager \watchMgr -> do
                   now <- getCurrentTime
                   (hashCache, timeCache) <- atomically do

--- a/fission-cli/library/Fission/CLI/Handler/App/Publish.hs
+++ b/fission-cli/library/Fission/CLI/Handler/App/Publish.hs
@@ -120,7 +120,10 @@ publish
               when open  do
                 liftIO . void . openBrowser $ ipfsGateway <> "/" <> show appURL
 
+              logDebug @Text ">>>>>>>>>>>> BEFORE WATCHING"
+
               when watching do
+                logDebug @Text ">>>>>>>>>>>> STARTED WATCHING"
                 liftIO $ FS.withManager \watchMgr -> do
                   now <- getCurrentTime
                   (hashCache, timeCache) <- atomically do
@@ -129,7 +132,7 @@ publish
                     return (hashCache, timeCache)
 
                   void $ handleTreeChanges runner proof appURL updateData timeCache hashCache watchMgr absBuildPath
-                  forever . liftIO $ threadDelay 1_000_000 -- Sleep main thread
+                  liftIO . forever $ threadDelay 1_000_000 -- Sleep main thread
 
               success appURL
 

--- a/fission-cli/package.yaml
+++ b/fission-cli/package.yaml
@@ -1,5 +1,5 @@
 name: fission-cli
-version: '2.14.1.0'
+version: '2.14.2.0'
 category: CLI
 author:
   - Brooklyn Zelenka


### PR DESCRIPTION
Turns out that `forever . lifIO` is not the same as `liftIO . forever` 😅  Which makes sense. _Which thing_ are you running forever? `liftIO :: IO a -> FissionCLI a` (i.e. embed IO action in a pure data structure), so we want the conversion on the _outside_.