### PR TITLE
Fix CLI publish directory with spaces

### DIFF
--- a/fission-cli/library/Fission/CLI/Handler/App/Publish.hs
+++ b/fission-cli/library/Fission/CLI/Handler/App/Publish.hs
@@ -97,7 +97,7 @@ publish
       logDebug $ "📱 Starting single IPFS add locally of " <> displayShow absBuildPath
       logUser @Text "🛫 App publish local preflight"
 
-      CLI.IPFS.Add.dir absBuildPath >>= \case
+      CLI.IPFS.Add.dir (UTF8.wrapIn "\"" absBuildPath) >>= \case
         Left err -> do
           CLI.Error.put' err
           raise err

--- a/fission-cli/package.yaml
+++ b/fission-cli/package.yaml
@@ -1,5 +1,5 @@
 name: fission-cli
-version: '2.14.2.0'
+version: '2.14.3.0'
 category: CLI
 author:
   - Brooklyn Zelenka

--- a/fission-core/library/Fission/Internal/UTF8.hs
+++ b/fission-core/library/Fission/Internal/UTF8.hs
@@ -22,7 +22,6 @@ module Fission.Internal.UTF8
   , stripNewline
   , textShow
   , wrapIn
-  , wrapInBS
   ) where
 
 import           Data.Base58String.Bitcoin as BS58.BTC
@@ -93,10 +92,7 @@ stripQuotesLazyBS = stripOptionalPrefixLazyBS "\"" . stripOptionalSuffixLazyBS "
 
 -- | Strip one newline character from the end of a lazy `ByteString`.
 stripNewline :: Lazy.ByteString -> Lazy.ByteString
-stripNewline bs =
-  bs
-    |> Lazy.stripSuffix "\n"
-    |> fromMaybe bs
+stripNewline bs = fromMaybe bs $ Lazy.stripSuffix "\n" bs
 
 -- | Show text.
 textShow :: Show a => a -> Text
@@ -106,7 +102,7 @@ textShow = textDisplay . displayShow
 stripNBS :: Natural -> Lazy.ByteString -> Lazy.ByteString
 stripNBS n bs =
   bs
-    |> Lazy.take ((Lazy.length bs) - i)
+    |> Lazy.take (Lazy.length bs - i)
     |> Lazy.drop i
   where
     i :: Int64
@@ -130,9 +126,6 @@ putTextLn txt = putText $ txt <> "\n"
 putNewline :: MonadIO m => m ()
 putNewline = putText "\n"
 
--- | Wrap text with some other piece of text.
-wrapIn :: Text -> Text -> Text
+-- | Wrap text with some other piece of text
+wrapIn :: Semigroup s => s -> s -> s
 wrapIn wrapper txt = wrapper <> txt <> wrapper
-
-wrapInBS :: ByteString -> ByteString -> ByteString
-wrapInBS wrapper bs = wrapper <> bs <> wrapper


### PR DESCRIPTION
There's currently an issue where paths containing spaces get treated as multiple commands on `stdin`. Wrapping the path in quotes resolves this issue (confirmed on macOS and Linux). Ideally we would handle this in `ipfs-haskell`, but there's a bunch of edge cases, and honestly that library needs a larger facelift. This one-liner resolves the issue for us.

# Before

<img width="801" alt="Screen Shot 2021-06-27 at 12 43 00" src="https://user-images.githubusercontent.com/1052016/123557330-39f4ec80-d745-11eb-80a4-79716b816ba4.png">

<img width="1437" alt="Screen Shot 2021-06-27 at 12 42 34" src="https://user-images.githubusercontent.com/1052016/123557318-2b0e3a00-d745-11eb-96f2-c1ceb51dc110.png">

# After

<img width="341" alt="Screen Shot 2021-06-27 at 12 40 26" src="https://user-images.githubusercontent.com/1052016/123557313-1b8ef100-d745-11eb-9a69-639f1749c762.png">
