### PR TITLE
Automigrate IPFS repo

### DIFF
--- a/fission-cli/library/Fission/CLI/Types.hs
+++ b/fission-cli/library/Fission/CLI/Types.hs
@@ -606,11 +606,11 @@ instance
 
         Turtle.export "IPFS_PATH" $ Text.pack ipfsRepo
 
-        process <- startProcess . fromString $ intercalate " "
+        process <- startProcess . fromString $ unwords
           [ "IPFS_PATH=" <> ipfsRepo
           , "2> /dev/null"
           , ipfsPath
-          , "daemon > /dev/null"
+          , "daemon --migrate > /dev/null"
           ]
 
         logDebug @Text "😈🏁 IPFS daemon started"

--- a/fission-cli/package.yaml
+++ b/fission-cli/package.yaml
@@ -1,5 +1,5 @@
 name: fission-cli
-version: '2.15.0.0'
+version: '2.15.1.0'
 category: CLI
 author:
   - Brooklyn Zelenka


### PR DESCRIPTION
IPFS 0.9 has a new `--migrate` flag on the daemon, which automigrates the repo on startup. This PR enables that flag.

I tested this manually by removing my existing repo, and setting up a new repo via my global IPFS 0.7 at the correct location (via `IPFS_PATH`), and then running `fission up`, which worked