### PR TITLE
Add new errors for a few failure cases

### DIFF
--- a/fission-cli/library/Fission/CLI/App.hs
+++ b/fission-cli/library/Fission/CLI/App.hs
@@ -14,6 +14,7 @@ import           Fission.CLI.Connected                   as Connected
 
 import           Fission.CLI.App.Environment             as App.Env
 import qualified Fission.CLI.Display.Error               as CLI.Error
+import           Fission.CLI.Environment                 as CLI.Env hiding (Env)
 import qualified Fission.CLI.Handler                     as Handler
 import           Fission.CLI.Handler.Error.Types         (Errs)
 
@@ -44,21 +45,32 @@ interpret baseCfg cmd = do
         run' :: FissionCLI errs Connected.Config () -> FissionCLI errs Base.Config ()
         run' = ensureM . Connected.run baseCfg timeoutSeconds
 
-      attempt App.Env.read >>= \case
-        Right Env {appURL} -> do
-          UTF8.putTextLn $ "App already set up at " <> textDisplay appURL
-          logDebug . textDisplay $ AlreadyExists @URL
-          raise $ AlreadyExists @URL
-
-        Left errs -> do
+      attempt CLI.Env.get >>= \case
+        Left errs ->
           case openUnionMatch @(NotFound FilePath) errs of
-            Just _ -> do
-              logDebug @Text "Setting up new app"
-              run' $ Handler.appInit appDir buildDir mayAppName
-
-            Nothing -> do
-              logError @Text "Problem setting up new app"
+            Just err -> do
+              CLI.Error.put err "Fission is installed, but you are not logged in. Please run `fission login`"
               raise errs
+
+            Nothing ->
+              raise errs
+
+        Right _ ->
+          attempt App.Env.read >>= \case
+            Right Env {appURL} -> do
+              UTF8.putTextLn $ "App already set up at " <> textDisplay appURL
+              logDebug . textDisplay $ AlreadyExists @URL
+              raise $ AlreadyExists @URL
+
+            Left errs -> do
+              case openUnionMatch @(NotFound FilePath) errs of
+                Just _ -> do
+                  logDebug @Text "Setting up new app"
+                  run' $ Handler.appInit appDir buildDir mayAppName
+
+                Nothing -> do
+                  logError @Text "Problem setting up new app"
+                  raise errs
 
     Up App.Up.Options {open, watch, updateDNS, updateData, filePath, ipfsCfg = IPFS.Config {..}} -> do
       let

--- a/fission-cli/library/Fission/CLI/App.hs
+++ b/fission-cli/library/Fission/CLI/App.hs
@@ -15,6 +15,7 @@ import           Fission.CLI.Connected                   as Connected
 import           Fission.CLI.App.Environment             as App.Env
 import qualified Fission.CLI.Display.Error               as CLI.Error
 import           Fission.CLI.Environment                 as CLI.Env hiding (Env)
+import           Fission.CLI.Error.Types
 import qualified Fission.CLI.Handler                     as Handler
 import           Fission.CLI.Handler.Error.Types         (Errs)
 
@@ -45,9 +46,9 @@ interpret baseCfg cmd = do
         run' :: FissionCLI errs Connected.Config () -> FissionCLI errs Base.Config ()
         run' = ensureM . Connected.run baseCfg timeoutSeconds
 
-      attempt CLI.Env.get >>= \case
+      attempt CLI.Env.alreadySetup >>= \case
         Left errs ->
-          case openUnionMatch @(NotFound FilePath) errs of
+          case openUnionMatch @NotSetup errs of
             Just err -> do
               CLI.Error.put err "Fission is installed, but you are not logged in. Please run `fission login`"
               raise errs

--- a/fission-cli/library/Fission/CLI/Connected.hs
+++ b/fission-cli/library/Fission/CLI/Connected.hs
@@ -165,7 +165,7 @@ mkConnected inCfg ipfsTimeout = do
             proof <- getRootUserProof
             attempt (sendAuthedRequest proof whoAmI) >>= \case
               Left err -> do
-                CLI.Error.put err "Not registered. Please run: fission user login"
+                CLI.Error.put err "Not registered. Please run `fission user login`"
                 raise NotRegistered
 
               Right username -> do

--- a/fission-cli/library/Fission/CLI/Connected.hs
+++ b/fission-cli/library/Fission/CLI/Connected.hs
@@ -59,6 +59,7 @@ type BaseErrs =
    , SomeException
    , IPFS.UnableToConnect
    , NotRegistered
+   , NotSetup
    , NotFound [IPFS.Peer]
    , NotFound Ed25519.SecretKey
    ]

--- a/fission-cli/library/Fission/CLI/Environment.hs
+++ b/fission-cli/library/Fission/CLI/Environment.hs
@@ -7,6 +7,7 @@ module Fission.CLI.Environment
   , getOrRetrievePeers
   , absPath
   , fetchServerDID
+  , alreadySetup
 
   -- * Reexport
 
@@ -15,6 +16,7 @@ module Fission.CLI.Environment
   ) where
 
 import qualified Data.ByteString.Char8         as BS8
+import           Data.Function
 import qualified Data.List.NonEmpty            as NonEmpty
 import qualified Data.Yaml                     as YAML
 
@@ -37,6 +39,7 @@ import           Fission.User.DID.Types
 import           Fission.User.Username.Types
 
 import qualified Fission.CLI.Display.Error     as CLI.Error
+import           Fission.CLI.Error.Types
 import           Fission.CLI.IPFS.Peers        as Peers
 import           Fission.CLI.Key.Store         as KeyStore
 import qualified Fission.CLI.YAML              as YAML
@@ -194,3 +197,21 @@ fetchServerDID fissionURL = do
         Right serverDID -> do
           logDebug $ "DID retrieved " <> textDisplay serverDID
           return serverDID
+
+alreadySetup ::
+  ( MonadRescue      m
+  , MonadLogger      m
+  , MonadIO          m
+  , MonadEnvironment m
+  , m `Raises` YAML.ParseException
+  , m `Raises` NotFound FilePath
+  , m `Raises` NotSetup
+  )
+  => m ()
+alreadySetup =
+  attemptM get \case
+    Left _ ->
+      raise NotSetup
+
+    Right _ ->
+      return ()

--- a/fission-cli/library/Fission/CLI/Error/Types.hs
+++ b/fission-cli/library/Fission/CLI/Error/Types.hs
@@ -1,5 +1,6 @@
 module Fission.CLI.Error.Types
   ( NotRegistered (..)
+  , NotSetup      (..)
   , NoKeyFile     (..)
   ) where
 
@@ -10,6 +11,14 @@ data NotRegistered = NotRegistered
 
 instance Display NotRegistered where
   display NotRegistered = "Not registered"
+
+----------
+
+data NotSetup = NotSetup
+  deriving (Show, Eq, Exception)
+
+instance Display NotSetup where
+  display NotSetup = "Not setup"
 
 ----------
 

--- a/fission-cli/library/Fission/CLI/Handler/App/Publish.hs
+++ b/fission-cli/library/Fission/CLI/Handler/App/Publish.hs
@@ -125,7 +125,15 @@ publish
           logUser @Text "✈️  Pushing to remote"
           retryOnStatus [status502] 100 (runUpdate cid) >>= \case
             Left err -> do
-              CLI.Error.put err "Server unable to sync data"
+              let errMsg =
+                    case err of
+                      FailureResponse _ (responseStatusCode -> status) | status == status404 ->
+                        "The app has not yet been registered. Please delete your fission.yaml and run `fission app register --name some-name`"
+
+                      _ ->
+                        "Server unable to sync data"
+
+              CLI.Error.put err errMsg
               raise err
 
             Right _ -> do

--- a/fission-cli/library/Fission/CLI/Handler/Error/Types.hs
+++ b/fission-cli/library/Fission/CLI/Handler/Error/Types.hs
@@ -82,6 +82,7 @@ type Errs
      , NotFound URL
      , NotFound [IPFS.Peer]
      , NotRegistered
+     , NotSetup
      --
      , OS.Unsupported
      , RSA.Error

--- a/fission-cli/library/Fission/CLI/Handler/User.hs
+++ b/fission-cli/library/Fission/CLI/Handler/User.hs
@@ -1,10 +1,11 @@
 module Fission.CLI.Handler.User (interpret) where
 
-import           Fission.Error
 import           Fission.Prelude
 
 import qualified Fission.CLI.Base.Types                      as Base
+
 import qualified Fission.CLI.Display.Error                   as CLI.Error
+import           Fission.CLI.Error.Types
 
 import           Fission.CLI.Environment                     as Env
 import           Fission.CLI.Types
@@ -33,9 +34,9 @@ interpret cmd = do
       return ()
 
     WhoAmI _ ->
-      attempt Env.get >>= \case
+      attemptM Env.alreadySetup \case
         Left errs ->
-          case openUnionMatch @(NotFound FilePath) errs of
+          case openUnionMatch @NotSetup errs of
             Just err -> do
               CLI.Error.put err "Fission is installed, but you are not logged in. Please run `fission login`"
               raise errs


### PR DESCRIPTION
## Summary
This PR resolves a few minor UX issues I ran into while using the tool today. In particular, it:
- Improves the error when running `app publish` with an unregistered app (closes #569)
- Adds a new error when running `app register` without a `config.yaml` (closes #538)
- Adds a new error when running `whoami` without a `config.yaml`
- Changes one pre-existing error message to have a consistent style with other similar error messages

Feel free to nitpick this as much as you'd like; I haven't worked with the repo before, and I'm out of practice with Haskell, so it's likely I'm missing some idioms!

In particular, I suspect some of these error strings should be pulled into `Fission.CLI.Error.Types`. Then I could probably define a helper somewhere that translates the `NotFound FilePath` into a `NotConfigured` error that more nicely encapsulates this concern.

I avoided doing that to keep these changes small and avoid imposing too large of a review burden onto anyone, but I'm happy to make any adjustments!

## Test plan (required)

`app publish` with an unregistered app:
```bash
[nix-shell:~/dev/fission]$ cat fission.yaml
ignore: []
url: does-not-exist.fission.app
build: ./assets

[nix-shell:~/dev/fission]$ stack run -- app publish
🕛🛫 App publish local preflight
🕑✈️  Pushing to remotePeer List...
🚫 The app has not yet been registered. Please delete your fission.yaml and run `fission app register --name some-name`

[nix-shell:~/dev/fission]$ rm fission.yaml

[nix-shell:~/dev/fission]$ stack run -- app register
👷 Choose build directory (.): assets
✅ App initialized as geriatric-yellow-centaur.fission.app
⏯️  Next run fission app publish [--open|--watch] to sync data
💁 It may take DNS time to propagate this initial setup globally. In this case, you can always view your app at https://ipfs.runfission.com/ipns/geriatric-yellow-centaur.fission.app

[nix-shell:~/dev/fission]$ stack run -- app publish
🕛🛫 App publish local preflight
🕒✈️  Pushing to remotePeer List...
🚀 Now live on the network
📝 DNS updated! Check out your site at: 
🔗 geriatric-yellow-centaur.fission.app
```

`app register` and `whoami` without being logged in:
```bash
[nix-shell:~/dev/fission]$ cat ~/.config/fission/config.yaml
cat: /Users/quinn/.config/fission/config.yaml: No such file or directory

[nix-shell:~/dev/fission]$ stack run -- app register
🚫 Fission is installed, but you are not logged in. Please run `fission login`

[nix-shell:~/dev/fission]$ stack run -- whoami      
🚫 Fission is installed, but you are not logged in. Please run `fission login`

[nix-shell:~/dev/fission]$ mv ~/.config/fission/config.yaml.old ~/.config/fission/config.yaml

[nix-shell:~/dev/fission]$ stack run -- app register
👷 Choose build directory (.): ^C

[nix-shell:~/dev/fission]$ stack run -- whoami
💻 Currently logged in as: quinn
```
