### PR TITLE
Ensure github requests always use TLS

### DIFF
--- a/fission-cli/library/Fission/CLI.hs
+++ b/fission-cli/library/Fission/CLI.hs
@@ -63,6 +63,7 @@ cli = do
         Http  -> defaultManagerSettings
         Https -> tlsManagerSettings
 
+  tlsManager <- liftIO $ HTTP.newManager tlsManagerSettings
   httpManager <- liftIO $ HTTP.newManager rawHTTPSettings
     { managerResponseTimeout = responseTimeoutMicro 1_800_000_000 }
 

--- a/fission-cli/library/Fission/CLI/Base/Types.hs
+++ b/fission-cli/library/Fission/CLI/Base/Types.hs
@@ -15,6 +15,7 @@ import           Fission.CLI.Remote
 -- | The configuration used for the CLI application
 data Config = Config
   { httpManager   :: HTTP.Manager
+  , tlsManager    :: HTTP.Manager
   , ipfsTimeout   :: IPFS.Timeout
   , ipfsURL       :: IPFS.URL
   , remote        :: Remote

--- a/fission-cli/library/Fission/CLI/Types.hs
+++ b/fission-cli/library/Fission/CLI/Types.hs
@@ -191,13 +191,13 @@ instance
   , Display (OpenUnion errs)
   , IsMember SomeException errs
 
-  , HasField' "httpManager" cfg HTTP.Manager
+  , HasField' "tlsManager"  cfg HTTP.Manager
   , HasLogFunc              cfg
   )
   => MonadGitHub (FissionCLI errs cfg) where
   sendRequest req =
     CLI.withLoader 50_000 do
-      manager <- asks $ getField @"httpManager"
+      manager <- asks $ getField @"tlsManager"
 
       logDebug @Text "🐱🐙 Making request to GitHub"
       liftIO . runClientM req . mkClientEnv manager $ BaseUrl Https "github.com" 443 ""

--- a/fission-cli/package.yaml
+++ b/fission-cli/package.yaml
@@ -1,5 +1,5 @@
 name: fission-cli
-version: '2.17.0.0'
+version: "2.17.1.0"
 category: CLI
 author:
   - Brooklyn Zelenka


### PR DESCRIPTION
Note: This issue only really impacts local development. 

We currently set up an `HTTP.Manager` globally based on the scheme of the fission server REST url. This means in local development (when using HTTP), the CLI will try to make a request to github via http. This PR adds a dedicated tlsManager that github requests will always use.