### PR TITLE
Bump to LTS-19.0 / GHC-9.0.2

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-18.24
+resolver: lts-19.0
 allow-newer: true # Needed for servant-ekg
 
 packages:
@@ -12,22 +12,18 @@ packages:
 
 extra-deps:
   - amazonka-1.6.1
+  - amazonka-core-1.6.1
+  - amazonka-route53-1.6.1
   - constraints-deriving-1.1.1.2
-  - cryptostore-0.2.1.0
   - dimensions-2.1.1.0
+  - ekg-core-0.1.1.7
+  - ekg-statsd-0.2.5.0
   - hfsevents-0.1.6
   - lzma-clib-5.2.2
   - raven-haskell-0.1.4.0
-  - rescue-0.4.2.1
   - servant-ekg-0.3.1
-  - servant-multipart-client-0.12.1
-  - servant-swagger-ui-redoc-0.3.4.1.22.3
-  - servant-websockets-2.0.0
   - unliftio-core-0.1.2.0
   - powerdns-0.2.2
-
-  # Waiting for github to make it back into Stackage LTS 18
-  - github-0.27
 
 ghc-options:
   "$everything": -haddock

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -12,6 +12,20 @@ packages:
   original:
     hackage: amazonka-1.6.1
 - completed:
+    hackage: amazonka-core-1.6.1@sha256:b94fe11830b5fa707a4372ebcc0e659759b3e885677e3ecaca2939b299b0bc96,5143
+    pantry-tree:
+      size: 3438
+      sha256: c3dc6d7d87310017d331e88d771db23df5b42aaee591edf23d5f10592e02eabc
+  original:
+    hackage: amazonka-core-1.6.1
+- completed:
+    hackage: amazonka-route53-1.6.1@sha256:a9839d8fc55de06a4fb242bc6597d454251363478909d4fe7dca8832c2a1fd73,5949
+    pantry-tree:
+      size: 14749
+      sha256: 47d8253fc03a0dbef989bd2c6fc8fdf6b46ede0b686111f375dd6f6c94e45b02
+  original:
+    hackage: amazonka-route53-1.6.1
+- completed:
     hackage: constraints-deriving-1.1.1.2@sha256:7e875b19b72920064e30ab722f01a7de2d4ee7840c2889c116297a4549262b72,4027
     pantry-tree:
       size: 3377
@@ -19,19 +33,26 @@ packages:
   original:
     hackage: constraints-deriving-1.1.1.2
 - completed:
-    hackage: cryptostore-0.2.1.0@sha256:9896e2984f36a1c8790f057fd5ce3da4cbcaf8aa73eb2d9277916886978c5b19,3881
-    pantry-tree:
-      size: 8596
-      sha256: e392f8dded050690140636b81433fb350bd87dd21643dde9a2f0aa344cf038e5
-  original:
-    hackage: cryptostore-0.2.1.0
-- completed:
     hackage: dimensions-2.1.1.0@sha256:ce33d4765e00e726ae7925f226fc685abd81afc7853cb861b4e04c186e90ad5a,2263
     pantry-tree:
       size: 1303
       sha256: 5e45ec67acfd851e448db156b7c24859c8447c48f7670080b330c64fc9039a4b
   original:
     hackage: dimensions-2.1.1.0
+- completed:
+    hackage: ekg-core-0.1.1.7@sha256:c4356aefea0e1e2f80a236d3b3f81b83b445c1e53519302e96477da0adee2e9f,2039
+    pantry-tree:
+      size: 1073
+      sha256: f403baeb7787c69c5e28f5aa1e94f78d4363beb19362d66f18de4a1aef0723fe
+  original:
+    hackage: ekg-core-0.1.1.7
+- completed:
+    hackage: ekg-statsd-0.2.5.0@sha256:167a3dc278cc8f68dd23d8e8dfc02754900cfd60ab215812742ac0fa4bae897c,1224
+    pantry-tree:
+      size: 280
+      sha256: c9999be1ea33918cebccd9a246c6cadf3b253e9b5bcc755f9702746193171653
+  original:
+    hackage: ekg-statsd-0.2.5.0
 - completed:
     hackage: hfsevents-0.1.6@sha256:295b29e8a4ac51a0015f4fb92b4140139d7b13ed691318159a20f85ce785dac6,863
     pantry-tree:
@@ -54,40 +75,12 @@ packages:
   original:
     hackage: raven-haskell-0.1.4.0
 - completed:
-    hackage: rescue-0.4.2.1@sha256:53256f87722af6f91e9e4ed18741c5e2515a0432ae7e94b16e3edf73931ec0c3,5025
-    pantry-tree:
-      size: 1963
-      sha256: 74b6dfd972089dba05241803a450e808348c5db6dc204810cc01161266c72194
-  original:
-    hackage: rescue-0.4.2.1
-- completed:
     hackage: servant-ekg-0.3.1@sha256:19bd9dc3943983da8e79d6f607614c68faea4054fb889d508c8a2b67b6bdd448,2203
     pantry-tree:
       size: 552
       sha256: 432766c31fdcd06fd2102d4d0ac63217c880d80d3bef4ad64b5b2ed95f8af355
   original:
     hackage: servant-ekg-0.3.1
-- completed:
-    hackage: servant-multipart-client-0.12.1@sha256:d043063e2f33eab86840f87c4bdb16eb3fe4a5847a0b118e4f4265cf3ba4c9b3,1892
-    pantry-tree:
-      size: 400
-      sha256: cb02eea7894a94e5dedf5cb74fd5fc6b989711ebb46a0e14d77f74f3b89dcbe0
-  original:
-    hackage: servant-multipart-client-0.12.1
-- completed:
-    hackage: servant-swagger-ui-redoc-0.3.4.1.22.3@sha256:538695996d0f925d2b7ac378c25eaff0cef6ca973afbdefb41db6b0ad133d0f0,1544
-    pantry-tree:
-      size: 381
-      sha256: 80f93d1bbdca9c08254642ed3b539172425d204cf1ffad288d02be33670f2d66
-  original:
-    hackage: servant-swagger-ui-redoc-0.3.4.1.22.3
-- completed:
-    hackage: servant-websockets-2.0.0@sha256:6e9e3600bced90fd52ed3d1bf632205cb21479075b20d6637153cc4567000234,2253
-    pantry-tree:
-      size: 523
-      sha256: 085c6620bff7671bef1d969652a349271c3703fbf10dd753cb63ee1cd700bca5
-  original:
-    hackage: servant-websockets-2.0.0
 - completed:
     hackage: unliftio-core-0.1.2.0@sha256:b0a7652ffce2284a6cebe05c99eb60573a8fb6631163f34b0b30a80b4a78cb23,1081
     pantry-tree:
@@ -102,16 +95,9 @@ packages:
       sha256: a768e597f56bafe2c1b367dae70375ba86417f4ce82babbd9a6e3eb0512b0fd6
   original:
     hackage: powerdns-0.2.2
-- completed:
-    hackage: github-0.27@sha256:074e69ad24b94b1199331b156e5373e9d4fa4a4452e02217f3539fe94a21a838,6995
-    pantry-tree:
-      size: 7838
-      sha256: b1c7b80c48aa78664cbf787ca3752d7e0389e32ad12c7912680ed10fd5c513ec
-  original:
-    hackage: github-0.27
 snapshots:
 - completed:
-    size: 587821
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/24.yaml
-    sha256: 06d844ba51e49907bd29cb58b4a5f86ee7587a4cd7e6cf395eeec16cba619ce8
-  original: lts-18.24
+    size: 616897
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/0.yaml
+    sha256: bbf2be02f17940bac1f87cb462d4fb0c3355de6dcfc53d84f4f9ad3ee2164f65
+  original: lts-19.0


### PR DESCRIPTION
_Almost_ compiles: I think we just need to update a subdependency in `ipfs-haskell` (conflicting Aeson). Why do we want GHC 9?

GHC 9.0
* "Full" LLVM-based codegen for aarch64-darwin (i.e. much better than GHC 8.10.5)

GHC 9.2 (available, but not yet on Stackage)
* _Native_ codegen for aarch64-darwin
* `-XGHC2021`
* Record dot syntax (what year is this?)

Stackage LTS-19.0 gets us on the major version (GHC 9.0.2). Nightly has switched to GHC 9.2.2