### PR TITLE
go-ipfs 0.12.2 & enable hole punching

### DIFF
--- a/fission-cli/library/Fission/CLI/IPFS/Configure.hs
+++ b/fission-cli/library/Fission/CLI/IPFS/Configure.hs
@@ -103,7 +103,7 @@ enableRelay ::
 enableRelay =
   ensureM $ IPFS.runLocal
     [ "config --bool"
-    , "Swarm.EnableRelayHop"
+    , "Swarm.RelayClient.Enabled"
     ]
     "true"
 

--- a/fission-cli/library/Fission/CLI/IPFS/Configure.hs
+++ b/fission-cli/library/Fission/CLI/IPFS/Configure.hs
@@ -5,6 +5,7 @@ module Fission.CLI.IPFS.Configure
   , setGatewayAddress
   , setSwarmAddresses
   , enableRelay
+  , enableHolePunching
   ) where
 
 import qualified RIO.ByteString.Lazy        as Lazy
@@ -103,5 +104,18 @@ enableRelay =
   ensureM $ IPFS.runLocal
     [ "config --bool"
     , "Swarm.EnableRelayHop"
+    ]
+    "true"
+
+enableHolePunching ::
+  ( MonadLocalIPFS m
+  , MonadRaise     m
+  , m `Raises` IPFS.Error
+  )
+  => m IPFS.RawMessage
+enableHolePunching =
+  ensureM $ IPFS.runLocal
+    [ "config --bool"
+    , "Swarm.EnableHolePunching"
     ]
     "true"

--- a/fission-cli/library/Fission/CLI/IPFS/Executable.hs
+++ b/fission-cli/library/Fission/CLI/IPFS/Executable.hs
@@ -71,7 +71,7 @@ place' host = do
   IPFS.BinPath ipfsPath <- Path.globalIPFSBin
 
   -- Network
-  ipfsBin <- ensureM . unpack =<< download (IPFS.Version 0 9 0) host
+  ipfsBin <- ensureM . unpack =<< download (IPFS.Version 0 12 2) host
 
   logDebug @Text "🚎 Moving IPFS into place..."
   File.lazyForceWrite ipfsPath ipfsBin

--- a/fission-cli/library/Fission/CLI/IPFS/Executable.hs
+++ b/fission-cli/library/Fission/CLI/IPFS/Executable.hs
@@ -118,7 +118,9 @@ configure ::
 configure = do
   logUser @Text "🎛️  Configuring managed IPFS"
   void IPFS.Config.init
+
   void IPFS.Config.enableRelay
+  void IPFS.Config.enableHolePunching
 
   void IPFS.Config.setApiAddress
   void IPFS.Config.setBootstrap

--- a/fission-cli/package.yaml
+++ b/fission-cli/package.yaml
@@ -1,5 +1,5 @@
 name: fission-cli
-version: "2.17.1.0"
+version: "2.17.2.0"
 category: CLI
 author:
   - Brooklyn Zelenka


### PR DESCRIPTION
https://github.com/fission-suite/fission/issues/590

On conference WiFi, even 😆 Stuff appears to continue to work (and was actually extremely fast this time)

```
[nix-shell:~/Documents/Work/Fission/fission]$ fission setup
🌱 Setting up environment
🪐 Downloading managed IPFS for macOS
🕕🎛️  Configuring managed IPFS
🔑 Setting up keys
🏠 Do you have an existing account? [Y/n] n
Username: expede-devconnect-21-04-22
Email: be.zelenka@gmail.com
✅ Registration successful! Head over to your email to confirm your account.
🎛️  Initializing user config file
✅ Done! Welcome to Fission, expede-devconnect-21-04-22 ✨

[nix-shell:~/Documents/Work/Fission/fission]$ mkdir ~/Desktop/foobar

[nix-shell:~/Documents/Work/Fission/fission]$ cd ~/Desktop/foobar

[nix-shell:~/Desktop/foobar]$ echo "hello world, this is a unique string from Devconnect '22" > test.txt

[nix-shell:~/Desktop/foobar]$ fission app register
👷 Choose build directory (.):
✅ App initialized as loyal-little-geriatric-golem.fission.app
⏯️  Next run fission app publish [--open|--watch] to sync data
💁 It may take DNS time to propagate this initial setup globally. In this case, you can always view your app at https://ipfs.runfission.com/ipns/loyal-little-geriatric-golem.fission.app

[nix-shell:~/Desktop/foobar]$ fission up
🕑🛫 App publish local preflight
🕖✈️  Pushing to remotePeer List...
🚀 Now live on the network
📝 DNS updated! Check out your site at:
🔗 loyal-little-geriatric-golem.fission.app

[nix-shell:~/Desktop/foobar]$ curl https://loyal-little-geriatric-golem.fission.app/test.txt
hello world, this is a unique string from Devconnect '22
```