### PR TITLE
Switch to list-transformer library & remove MonadWalk

### DIFF
--- a/hs-ucan/library/Web/UCAN/DelegationChain/StreamWithErrors.hs
+++ b/hs-ucan/library/Web/UCAN/DelegationChain/StreamWithErrors.hs
@@ -1,22 +1,15 @@
-module Web.UCAN.DelegationChain.Class
-  ( MonadWalk(..)
-  , StreamWithErrors(..)
+module Web.UCAN.DelegationChain.StreamWithErrors
+  ( StreamWithErrors(..)
   ) where
 
 import           Control.Applicative
 import           Control.Monad
-import           ListT                   (ListT)
-import qualified ListT
+import           List.Transformer        (ListT)
 import           RIO
 
 import           Control.Monad.Except
 import           Web.UCAN.Error
 import           Web.UCAN.Resolver.Class
-
-
--- | A monad abstracting over iterating elements
-class Alternative m => MonadWalk m where
-  walk :: Foldable f => f a -> m a
 
 
 newtype StreamWithErrors m a
@@ -35,10 +28,6 @@ instance Monad m => Monad (StreamWithErrors m) where
   StreamWithErrors ma >>= f =
     StreamWithErrors $
       ma >>= either (return . Left) (runStreamWithErrors . f)
-
-
-instance Monad m => MonadWalk (StreamWithErrors m) where
-  walk = StreamWithErrors . fmap Right . ListT.fromFoldable
 
 
 instance Monad m => Alternative (StreamWithErrors m) where

--- a/hs-ucan/library/Web/UCAN/DelegationChain/StreamWithErrors.hs
+++ b/hs-ucan/library/Web/UCAN/DelegationChain/StreamWithErrors.hs
@@ -31,7 +31,7 @@ instance Monad m => Monad (StreamWithErrors m) where
 
 
 instance Monad m => Alternative (StreamWithErrors m) where
-  empty = StreamWithErrors $ empty
+  empty = StreamWithErrors empty
   StreamWithErrors a <|> StreamWithErrors b = StreamWithErrors (a <|> b)
 
 

--- a/hs-ucan/package.yaml
+++ b/hs-ucan/package.yaml
@@ -123,7 +123,7 @@ dependencies:
   - generic-lens
   - hashable
   - lens
-  - list-t
+  - list-transformer
   - megaparsec
   - memory
   - QuickCheck

--- a/hs-ucan/test/Test/Web/UCAN/Attenuation.hs
+++ b/hs-ucan/test/Test/Web/UCAN/Attenuation.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE QuasiQuotes #-}
 module Test.Web.UCAN.Attenuation (spec) where
 

--- a/hs-ucan/test/Test/Web/UCAN/Orphanage/DummyResolver.hs
+++ b/hs-ucan/test/Test/Web/UCAN/Orphanage/DummyResolver.hs
@@ -1,5 +1,5 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Test.Web.UCAN.Orphanage.DummyResolver where
+module Test.Web.UCAN.Orphanage.DummyResolver () where
 
 import           Test.Web.UCAN.Prelude
 import           Web.UCAN.Resolver


### PR DESCRIPTION
`MonadWalk` is superseded by `Alternative`.
The `list-t` library doesn't have the `select` function that `list-transformer` has and both libraries export exactly isomorphic `ListT` types.
