### PR TITLE
Migrate nix environment to flakes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -590,3 +590,4 @@ MigrationBackup/
 
 fission-web-server/data/
 fission-web-server/.env
+.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1654562072,
+        "narHash": "sha256-00r0/W+c3LOWMCw5l1uhZRJHY2CUPNQHqO2rnZCIuFk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a45d53b958df713f0072791b993ae57074c9bf99",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,52 @@
+{
+  description = "Fission tools";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/release-22.05";
+    flake-utils.url = "github:numtide/flake-utils";
+
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          # Inspired by https://www.tweag.io/blog/2022-06-02-haskell-stack-nix-shell/
+          stack-wrapped = pkgs.symlinkJoin {
+            name = "stack";
+            paths = [ pkgs.stack ];
+            buildInputs = [ pkgs.makeWrapper ];
+            postBuild = ''
+              wrapProgram $out/bin/stack \
+                --add-flags "\
+                  --nix \
+                  --no-nix-pure \
+                  --nix-shell-file=nix/stack-integration.nix \
+                "
+            '';
+          };
+
+          # The default version of HLS (with binary cache) is built with GHC 9.0.1
+          # We can get this version working with our current set up, but it builds 
+          # from source (and takes a long time).
+          #
+          # The prebuilt package is marked as broken on aarch64-darwin
+          haskellPackages = pkgs.haskell.packages.ghc8107;
+        in
+        {
+          devShells.default = pkgs.mkShell {
+            name = "fission";
+            buildInputs = [
+              stack-wrapped
+              haskellPackages.haskell-language-server
+            ];
+            NIX_PATH = "nixpkgs=" + pkgs.path;
+          };
+        }
+      );
+}

--- a/nix/stack-integration.nix
+++ b/nix/stack-integration.nix
@@ -1,0 +1,18 @@
+{ ghc }:
+with (import <nixpkgs> { });
+
+haskell.lib.buildStackProject {
+  inherit ghc;
+  name = "fission";
+  buildInputs = [
+    lzma
+    openssl
+    postgresql
+    zlib
+
+    # TODO: this should only be on darwin
+    darwin.apple_sdk.frameworks.CoreServices
+    darwin.apple_sdk.frameworks.Foundation
+    darwin.apple_sdk.frameworks.Cocoa
+  ];
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,76 +1,13 @@
-{ rosetta ? false }:
-  let
-    sources  = import ./nix/sources.nix;
-    commands = import ./nix/commands.nix;
-
-    overrides = if rosetta then { system = "x86_64-darwin"; } else {};
-
-    nixos    = import sources.nixos    overrides;
-    darwin   = import sources.darwin   overrides;
-    unstable = import sources.unstable overrides;
-
-    pkgs  = if darwin.stdenv.isDarwin then darwin else nixos;
-    tasks = commands {
-      inherit pkgs;
-      inherit unstable;
-      inherit server-path;
-      inherit server-port;
-    };
-
-    server-path = "~/.local/bin/fission-server";
-    server-port = 10235;
-
-    deps = {
-      common = [
-        unstable.niv
-      ];
-
-    crypto = [
-      pkgs.openssl.dev
-      pkgs.openssl.out
-    ];
-
-    cli = [pkgs.ncurses.dev.out];
-
-    data = [
-      pkgs.ipfs
-      pkgs.lzma.dev
-      pkgs.lzma.out
-      pkgs.zlib.dev
-      pkgs.zlib.out
-      pkgs.postgresql
-    ];
-
-    haskell = [
-      unstable.haskell-language-server
-      unstable.stack
-      unstable.stylish-haskell
-    ];
-
-    macos =
-      if pkgs.stdenv.isDarwin then
-        [ unstable.darwin.apple_sdk.frameworks.CoreServices
-          unstable.darwin.apple_sdk.frameworks.Foundation
-          unstable.darwin.apple_sdk.frameworks.Cocoa
-        ]
-      else
-        [];
-  };
-
-  in
-    unstable.haskell.lib.buildStackProject {
-      name = "Fission";
-      nativeBuildInputs = builtins.concatLists [
-        deps.common
-        deps.crypto
-        deps.cli
-        deps.data
-        deps.macos
-        deps.haskell
-        tasks
-      ];
-
-      shellHook = ''
-        export LANG=C.UTF8
-      '';
+(import
+  (
+    let
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
     }
+  )
+  {
+    src = ./.;
+  }).shellNix.default

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-18.24
+resolver: lts-18.28
 allow-newer: true # Needed for servant-ekg
 
 packages:
@@ -31,8 +31,3 @@ extra-deps:
 
 ghc-options:
   "$everything": -haddock
-
-nix:
-  enable: true
-  pure: true
-  shell-file: shell.nix

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,113 +5,113 @@
 
 packages:
 - completed:
-    hackage: amazonka-1.6.1@sha256:f58b63e83876f93aa03c54e54b3eb8ba9358af93819d41f4a5a8f8b7d8b8399c,3544
     pantry-tree:
-      size: 992
       sha256: d792656a70ee42df262a599bc6608bda069e33092d665c3438a6eeeaf7db4fb2
+      size: 992
+    hackage: amazonka-1.6.1@sha256:f58b63e83876f93aa03c54e54b3eb8ba9358af93819d41f4a5a8f8b7d8b8399c,3544
   original:
     hackage: amazonka-1.6.1
 - completed:
-    hackage: constraints-deriving-1.1.1.2@sha256:7e875b19b72920064e30ab722f01a7de2d4ee7840c2889c116297a4549262b72,4027
     pantry-tree:
-      size: 3377
       sha256: 49c39bb5d120a14f475964b6337288590f12374e94471e6e637c4ca0f5553988
+      size: 3377
+    hackage: constraints-deriving-1.1.1.2@sha256:7e875b19b72920064e30ab722f01a7de2d4ee7840c2889c116297a4549262b72,4027
   original:
     hackage: constraints-deriving-1.1.1.2
 - completed:
-    hackage: cryptostore-0.2.1.0@sha256:9896e2984f36a1c8790f057fd5ce3da4cbcaf8aa73eb2d9277916886978c5b19,3881
     pantry-tree:
-      size: 8596
       sha256: e392f8dded050690140636b81433fb350bd87dd21643dde9a2f0aa344cf038e5
+      size: 8596
+    hackage: cryptostore-0.2.1.0@sha256:9896e2984f36a1c8790f057fd5ce3da4cbcaf8aa73eb2d9277916886978c5b19,3881
   original:
     hackage: cryptostore-0.2.1.0
 - completed:
-    hackage: dimensions-2.1.1.0@sha256:ce33d4765e00e726ae7925f226fc685abd81afc7853cb861b4e04c186e90ad5a,2263
     pantry-tree:
-      size: 1303
       sha256: 5e45ec67acfd851e448db156b7c24859c8447c48f7670080b330c64fc9039a4b
+      size: 1303
+    hackage: dimensions-2.1.1.0@sha256:ce33d4765e00e726ae7925f226fc685abd81afc7853cb861b4e04c186e90ad5a,2263
   original:
     hackage: dimensions-2.1.1.0
 - completed:
-    hackage: hfsevents-0.1.6@sha256:295b29e8a4ac51a0015f4fb92b4140139d7b13ed691318159a20f85ce785dac6,863
     pantry-tree:
-      size: 438
       sha256: 14370510ec9a045fdc5b7e614279a84e3540a968f8b5ad12b8796916c4d6d1ee
+      size: 438
+    hackage: hfsevents-0.1.6@sha256:295b29e8a4ac51a0015f4fb92b4140139d7b13ed691318159a20f85ce785dac6,863
   original:
     hackage: hfsevents-0.1.6
 - completed:
-    hackage: lzma-clib-5.2.2@sha256:25eb43d5fd8a8ab58380f475b91fb1fa907381f8a81c8d8ba63ba428d97ae0cc,4900
     pantry-tree:
-      size: 11577
       sha256: ed5ce184eaad3b4239f86d1d478d0b5ed6a93af5aac72f19f376c1690585576d
+      size: 11577
+    hackage: lzma-clib-5.2.2@sha256:25eb43d5fd8a8ab58380f475b91fb1fa907381f8a81c8d8ba63ba428d97ae0cc,4900
   original:
     hackage: lzma-clib-5.2.2
 - completed:
-    hackage: raven-haskell-0.1.4.0@sha256:64eca8650d140fc853a951af0cf4e2ce255b90491b9e3014d82be2e79593c43a,1251
     pantry-tree:
-      size: 632
       sha256: 19c2aaf9c09d341108777e3a4de975841f81518ed271b156983d25ec622dd266
+      size: 632
+    hackage: raven-haskell-0.1.4.0@sha256:64eca8650d140fc853a951af0cf4e2ce255b90491b9e3014d82be2e79593c43a,1251
   original:
     hackage: raven-haskell-0.1.4.0
 - completed:
-    hackage: rescue-0.4.2.1@sha256:53256f87722af6f91e9e4ed18741c5e2515a0432ae7e94b16e3edf73931ec0c3,5025
     pantry-tree:
-      size: 1963
       sha256: 74b6dfd972089dba05241803a450e808348c5db6dc204810cc01161266c72194
+      size: 1963
+    hackage: rescue-0.4.2.1@sha256:53256f87722af6f91e9e4ed18741c5e2515a0432ae7e94b16e3edf73931ec0c3,5025
   original:
     hackage: rescue-0.4.2.1
 - completed:
-    hackage: servant-ekg-0.3.1@sha256:19bd9dc3943983da8e79d6f607614c68faea4054fb889d508c8a2b67b6bdd448,2203
     pantry-tree:
-      size: 552
       sha256: 432766c31fdcd06fd2102d4d0ac63217c880d80d3bef4ad64b5b2ed95f8af355
+      size: 552
+    hackage: servant-ekg-0.3.1@sha256:19bd9dc3943983da8e79d6f607614c68faea4054fb889d508c8a2b67b6bdd448,2203
   original:
     hackage: servant-ekg-0.3.1
 - completed:
-    hackage: servant-multipart-client-0.12.1@sha256:d043063e2f33eab86840f87c4bdb16eb3fe4a5847a0b118e4f4265cf3ba4c9b3,1892
     pantry-tree:
-      size: 400
       sha256: cb02eea7894a94e5dedf5cb74fd5fc6b989711ebb46a0e14d77f74f3b89dcbe0
+      size: 400
+    hackage: servant-multipart-client-0.12.1@sha256:d043063e2f33eab86840f87c4bdb16eb3fe4a5847a0b118e4f4265cf3ba4c9b3,1892
   original:
     hackage: servant-multipart-client-0.12.1
 - completed:
-    hackage: servant-swagger-ui-redoc-0.3.4.1.22.3@sha256:538695996d0f925d2b7ac378c25eaff0cef6ca973afbdefb41db6b0ad133d0f0,1544
     pantry-tree:
-      size: 381
       sha256: 80f93d1bbdca9c08254642ed3b539172425d204cf1ffad288d02be33670f2d66
+      size: 381
+    hackage: servant-swagger-ui-redoc-0.3.4.1.22.3@sha256:538695996d0f925d2b7ac378c25eaff0cef6ca973afbdefb41db6b0ad133d0f0,1544
   original:
     hackage: servant-swagger-ui-redoc-0.3.4.1.22.3
 - completed:
-    hackage: servant-websockets-2.0.0@sha256:6e9e3600bced90fd52ed3d1bf632205cb21479075b20d6637153cc4567000234,2253
     pantry-tree:
-      size: 523
       sha256: 085c6620bff7671bef1d969652a349271c3703fbf10dd753cb63ee1cd700bca5
+      size: 523
+    hackage: servant-websockets-2.0.0@sha256:6e9e3600bced90fd52ed3d1bf632205cb21479075b20d6637153cc4567000234,2253
   original:
     hackage: servant-websockets-2.0.0
 - completed:
-    hackage: unliftio-core-0.1.2.0@sha256:b0a7652ffce2284a6cebe05c99eb60573a8fb6631163f34b0b30a80b4a78cb23,1081
     pantry-tree:
-      size: 328
       sha256: 9d970bf5f98e68e8fc129b04d6c9d8eb1e641c7556ffd0f0a168a259335b6fd7
+      size: 328
+    hackage: unliftio-core-0.1.2.0@sha256:b0a7652ffce2284a6cebe05c99eb60573a8fb6631163f34b0b30a80b4a78cb23,1081
   original:
     hackage: unliftio-core-0.1.2.0
 - completed:
-    hackage: powerdns-0.2.2@sha256:2e0d152c26e31127adcec24525c51c40faca04de8c67d1a914050d1882968871,2601
     pantry-tree:
-      size: 828
       sha256: a768e597f56bafe2c1b367dae70375ba86417f4ce82babbd9a6e3eb0512b0fd6
+      size: 828
+    hackage: powerdns-0.2.2@sha256:2e0d152c26e31127adcec24525c51c40faca04de8c67d1a914050d1882968871,2601
   original:
     hackage: powerdns-0.2.2
 - completed:
-    hackage: github-0.27@sha256:074e69ad24b94b1199331b156e5373e9d4fa4a4452e02217f3539fe94a21a838,6995
     pantry-tree:
-      size: 7838
       sha256: b1c7b80c48aa78664cbf787ca3752d7e0389e32ad12c7912680ed10fd5c513ec
+      size: 7838
+    hackage: github-0.27@sha256:074e69ad24b94b1199331b156e5373e9d4fa4a4452e02217f3539fe94a21a838,6995
   original:
     hackage: github-0.27
 snapshots:
 - completed:
-    size: 587821
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/24.yaml
-    sha256: 06d844ba51e49907bd29cb58b4a5f86ee7587a4cd7e6cf395eeec16cba619ce8
-  original: lts-18.24
+    sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68
+    size: 590100
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/28.yaml
+  original: lts-18.28


### PR DESCRIPTION
** VERY WIP ** 

This will close #584 

Adding `flake.nix` for faster nix-shell startup and better version pinning. In the process, generally cleaning up some issues (mostly around `aarch64-darwin`):

- Remove `rosetta` arg for building natively on M1
- Make sure HLS works in multiple environments
- remove the `--nix` vs `--no-nix` dance for stack (if you're using nix, automatically build with --nix but otherwise let folks use stack as normal).
