### PR TITLE
Append endpoint DAG surgery

### DIFF
--- a/fission-cli/library/Fission/CLI/Handler/Error/Types.hs
+++ b/fission-cli/library/Fission/CLI/Handler/Error/Types.hs
@@ -10,6 +10,7 @@ import qualified Crypto.PubKey.RSA.Types               as RSA
 
 import           Network.DNS                           as DNS
 import qualified Network.IPFS.Add.Error                as IPFS.Add
+import qualified Network.IPFS.Files.Error              as IPFS.Files
 import           Network.IPFS.CID.Types
 import qualified Network.IPFS.Process.Error            as IPFS.Process
 import qualified Network.IPFS.Types                    as IPFS
@@ -61,6 +62,7 @@ type Errs
      , Status Denied
      --
      , IPFS.Add.Error
+     , IPFS.Files.Error
      , IPFS.Process.Error
      , IPFS.UnableToConnect
      --

--- a/fission-web-api/library/Fission/Web/API/Append/Types.hs
+++ b/fission-web-api/library/Fission/Web/API/Append/Types.hs
@@ -9,7 +9,7 @@ import qualified Fission.Web.API.Auth.Types              as Auth
 import           Fission.FileSystem.DirectoryName.Types  as DirectoryName
 import           Fission.FileSystem.FileName.Types       as FileName
 
-data RoutesV2 mode = RoutesV2
+newtype RoutesV2 mode = RoutesV2
   { append ::
       mode
       :- Summary     "Append a file"

--- a/fission-web-api/library/Fission/Web/API/Append/Types.hs
+++ b/fission-web-api/library/Fission/Web/API/Append/Types.hs
@@ -1,6 +1,7 @@
 module Fission.Web.API.Append.Types (RoutesV2 (..)) where
 
 import           Network.IPFS.File.Types                 as File
+import           Network.IPFS.CID.Types
 
 import           Fission.Web.API.Prelude
 
@@ -21,6 +22,6 @@ newtype RoutesV2 mode = RoutesV2
       :> ReqBody '[OctetStream] Serialized
       --
       :> Auth.HigherOrder
-      :> PutNoContent
+      :> PutAccepted '[JSON] CID
   }
   deriving Generic

--- a/fission-web-server/README.md
+++ b/fission-web-server/README.md
@@ -57,7 +57,7 @@ To mimic the full "fission stack" for local development, you can use the include
    - `docker compose exec dns-auth pdnsutil add-record fissionuser.test. gateway A "127.0.0.1"`
    - `docker compose exec dns-auth pdnsutil add-record fissionapp.test. gateway A "127.0.0.1"`
 5. Point your local DNS resolver to localhost.
-   - on macOS: this is under System Preferences > Network > Advanced.
+   - on macOS: this is under System Preferences > Network > Advanced (make sure your local IP is at the top of the list)
    - on Linux: Add `nameserver 127.0.0.1` to `/etc/resolv.conf`
 6. Pin the CID for the new app placeholder:
    `docker compose exec ipfs ipfs pin add -r QmRVvvMeMEPi1zerpXYH9df3ATdzuB63R1wf3Mz5NS5HQN`
@@ -85,3 +85,9 @@ If you don't see that, you can try the following steps:
 1. Ensure the local DNS server is set up for the zone, e.g. `dig runfission.test -p 5300 @127.0.0.1`. If that fails, make sure the zone is created (see above).
 2. Ensure the local resolver is working, e.g. `dig runfission.test @127.0.0.1`. If that fails, make sure the zone exists in `.env`.
 3. If `dig runfission.test` still fails, ensure your system is set to use the local resolver. Also, try disabling any VPN software (Tailscale, etc) as they may conflict with DNS resolution.
+
+#### Practical
+
+- Connecting to the database: `docker compose exec postgres psql`
+- You can lookup DNSLinks using `dig -t TXT _dnslink.HOST` (eg. `dig -t TXT _dnslink.icidasset.files.fissionuser.test`)
+- Interacting with the IPFS CLI connected to the IPFS daemon: `docker compose exec ipfs ipfs ...`

--- a/fission-web-server/library/Fission/Web/Server.hs
+++ b/fission-web-server/library/Fission/Web/Server.hs
@@ -42,6 +42,7 @@ import qualified Fission.Web.Server.App.Domain                as App.Domain
 import           Fission.Web.Server.Handler
 import qualified Fission.Web.Server.Handler.Auth.UCAN         as Auth.UCAN
 
+import           Fission.Web.Server.Config.Types
 import           Fission.Web.Server.IPFS.Cluster              as Cluster
 import           Fission.Web.Server.IPFS.Linked
 import           Fission.Web.Server.MonadDB
@@ -70,6 +71,7 @@ app :: forall m t .
   , MonadDNSLink                m
   , MonadWNFS                   m
   , MonadLogger                 m
+  , MonadReader Config          m
   , MonadTime                   m
   , MonadEmail                  m
   , User.CRUD                   m
@@ -86,6 +88,7 @@ app :: forall m t .
   , LoosePin.CRUD             t
   , User.Retriever            t
   , User.Destroyer            t
+  , App.Modifier              t
   , App.Retriever             t
   , App.Domain.Retriever      t
   )
@@ -116,6 +119,7 @@ server ::
   , MonadDNSLink                m
   , MonadWNFS                   m
   , MonadLogger                 m
+  , MonadReader Config          m
   , MonadTime                   m
   , MonadEmail                  m
   , User.CRUD                   m
@@ -132,6 +136,7 @@ server ::
   , LoosePin.CRUD             t
   , User.Retriever            t
   , User.Destroyer            t
+  , App.Modifier              t
   , App.Retriever             t
   , App.Domain.Retriever      t
   )
@@ -173,4 +178,4 @@ server appHost =
       }
 
     v2Docs =
-      Web.Swagger.handler fromHandler appHost Fission.version (Proxy @("v2" :> (ToServantApi Fission.RoutesV2)))
+      Web.Swagger.handler fromHandler appHost Fission.version (Proxy @("v2" :> ToServantApi Fission.RoutesV2))

--- a/fission-web-server/library/Fission/Web/Server.hs
+++ b/fission-web-server/library/Fission/Web/Server.hs
@@ -38,6 +38,7 @@ import qualified Fission.Web.Server.LoosePin                  as LoosePin
 import qualified Fission.Web.Server.App                       as App
 import qualified Fission.Web.Server.App.Content               as App.Content
 import qualified Fission.Web.Server.App.Domain                as App.Domain
+import qualified Fission.Web.Server.Domain.Retriever.Class    as Domain
 
 import           Fission.Web.Server.Handler
 import qualified Fission.Web.Server.Handler.Auth.UCAN         as Auth.UCAN
@@ -60,8 +61,10 @@ import qualified Paths_fission_web_server                     as Fission
 -- | Top level web API type. Handled by 'server'.
 app :: forall m t .
   ( App.Domain.Initializer      m
+  , App.Domain.Retriever        m
   , App.Content.Initializer     m
   , App.CRUD                    m
+  , Domain.Retriever            m
   , Proof.Resolver              m
   , MonadReflectiveServer       m
   , MonadRelayStore             m
@@ -108,8 +111,10 @@ app handlerNT authChecks appHost =
 -- | Web handlers for the 'API'
 server ::
   ( App.Domain.Initializer      m
+  , App.Domain.Retriever        m
   , App.Content.Initializer     m
   , App.CRUD                    m
+  , Domain.Retriever            m
   , Proof.Resolver              m
   , MonadReflectiveServer       m
   , MonadRelayStore             m

--- a/fission-web-server/library/Fission/Web/Server/App/Modifier.hs
+++ b/fission-web-server/library/Fission/Web/Server/App/Modifier.hs
@@ -1,5 +1,6 @@
 module Fission.Web.Server.App.Modifier
   ( module Fission.Web.Server.App.Modifier.Class
+  , addFile
   , setCidDB
   ) where
 
@@ -8,17 +9,117 @@ import           Database.Persist                                   as Persist
 
 import           Network.IPFS.Bytes.Types
 import           Network.IPFS.CID.Types
+import qualified Network.IPFS.Files                                 as IPFS.Files
+import qualified Network.IPFS.Pin                                   as IPFS.Pin
+import qualified Network.IPFS.Stat                                  as IPFS.Stat
+
+import           Network.IPFS.Local.Class (MonadLocalIPFS)
+import           Network.IPFS.Remote.Class (MonadRemoteIPFS)
+
+import qualified RIO.ByteString.Lazy                                as Lazy
+import           RIO.Text                                           as Text
 
 import           Fission.Prelude                                    hiding (on)
 
 import           Fission.Error                                      as Error
+import           Fission.FileSystem.DirectoryName
+import           Fission.FileSystem.FileName
 import           Fission.URL
 
 import           Fission.Web.Server.App.Modifier.Class
+import           Fission.Web.Server.App.Retriever.Class (Retriever)
+import qualified Fission.Web.Server.App.Retriever.Class             as App.Retriever
+import           Fission.Web.Server.Config.Types
 import           Fission.Web.Server.Error.ActionNotAuthorized.Types
 import           Fission.Web.Server.Models
-import           Fission.Web.Server.MonadDB
+import           Fission.Web.Server.MonadDB.Class (MonadDB(..))
+import           Fission.Web.Server.MonadDB.Types (Transaction)
 import           Fission.Web.Server.Ownership
+
+
+{-| Adds a file to an app.
+
+Notes:
+* Overwrites existing file data
+* Uses IPFS MFS as a temporary storage to manipulate the DAG structure
+
+-}
+addFile ::
+  ( MonadDB t m
+  , MonadLogger m
+  , MonadReader Config m
+  , MonadRemoteIPFS m
+  , MonadTime m
+  , Modifier t
+  , Retriever m
+  )
+  => UserId
+  -> DirectoryName
+  -> FileName
+  -> Lazy.ByteString
+  -> m (Either Errors' ())
+addFile userId appName@(DirectoryName appNameText) fileName rawData = do
+  now           <- currentTime
+  domainName    <- asks baseAppDomain
+
+  mayApp        <- App.Retriever.byURL
+                    userId
+                    (URL domainName $ Just $ Subdomain appNameText)
+
+  case mayApp of
+    Left _ -> do
+      return . Error.openLeft $ NotFound @App
+
+    Right (Entity appId app@App {appCid}) ->
+      if isOwnedBy userId app then do
+        -- Update DAG & DB
+        appendToDag appName fileName rawData appCid >>= \case
+          Left err ->
+            return $ Left err
+
+          Right newCID ->
+            IPFS.Stat.getSizeRemote newCID >>= \case
+              Left err ->
+                return . Error.openLeft $ err
+
+              Right size -> do
+                runDB (setCIDDirectly now appId size newCID)
+                return $ Right ()
+
+      else
+        return . Error.openLeft $ ActionNotAuthorized @App userId
+
+
+appendToDag ::
+  ( MonadRemoteIPFS m
+  , MonadLogger m
+  )
+  => DirectoryName
+  -> FileName
+  -> Lazy.ByteString
+  -> CID
+  -> m (Either Errors' CID)
+appendToDag (DirectoryName appName) (FileName fileName) rawData appCid = do
+  let domainName = "fission.app"
+  let appCidText = unaddress appCid
+
+  let tmpDirPath = Text.concat [ "/", domainName, "/", appName, "/" ]
+  let distDirPath = Text.concat [ tmpDirPath, appCidText, "/" ]
+  let filePath = Text.concat [ distDirPath, fileName ]
+
+  IPFS.Files.cp (Left appCid) (Text.unpack tmpDirPath)
+  IPFS.Files.write (Text.unpack filePath) rawData
+  IPFS.Files.statCID (Text.unpack distDirPath) >>= \case
+
+    Left err ->
+      return . Error.openLeft $ err
+
+    Right newCID -> do
+      _ <- IPFS.Pin.add newCID
+      IPFS.Files.rm (Text.unpack distDirPath)
+
+      return $ Right newCID
+
 
 setCidDB ::
      MonadIO m

--- a/fission-web-server/library/Fission/Web/Server/App/Modifier.hs
+++ b/fission-web-server/library/Fission/Web/Server/App/Modifier.hs
@@ -80,7 +80,9 @@ addFile userId appName@(DirectoryName appNameText) fileName rawData = do
     Right (Entity appId app@App {appCid}) ->
       if isOwnedBy userId app then do
         -- Update DAG, DNSLink & DB
-        appendToDag appName fileName rawData appCid >>= \case
+        let (DomainName domainNameTxt) = domainName
+
+        appendToDag domainNameTxt appName fileName rawData appCid >>= \case
           Left err ->
             return $ Left err
 
@@ -109,13 +111,13 @@ appendToDag ::
   ( MonadRemoteIPFS m
   , MonadLogger m
   )
-  => DirectoryName
+  => Text
+  -> DirectoryName
   -> FileName
   -> Lazy.ByteString
   -> CID
   -> m (Either Errors' CID)
-appendToDag (DirectoryName appName) (FileName fileName) rawData appCid = do
-  let domainName = "fission.app"
+appendToDag domainName (DirectoryName appName) (FileName fileName) rawData appCid = do
   let appCidText = unaddress appCid
 
   let tmpDirPath = Text.concat [ "/", domainName, "/", appName, "/" ]

--- a/fission-web-server/library/Fission/Web/Server/App/Modifier.hs
+++ b/fission-web-server/library/Fission/Web/Server/App/Modifier.hs
@@ -120,9 +120,9 @@ appendToDag ::
 appendToDag domainName (DirectoryName appName) (FileName fileName) rawData appCid = do
   let appCidText = unaddress appCid
 
-  let tmpDirPath = Text.concat [ "/", domainName, "/", appName, "/" ]
-  let distDirPath = Text.concat [ tmpDirPath, appCidText, "/" ]
-  let filePath = Text.concat [ distDirPath, "uploads/", fileName ]
+  let tmpDirPath = "/" <> domainName <> "/" <> appName <> "/"
+  let distDirPath = tmpDirPath <> appCidText <> "/"
+  let filePath = distDirPath <> "uploads/" <> fileName
 
   IPFS.Files.cp (Left appCid) (Text.unpack tmpDirPath)
   IPFS.Files.write (Text.unpack filePath) rawData

--- a/fission-web-server/library/Fission/Web/Server/App/Modifier.hs
+++ b/fission-web-server/library/Fission/Web/Server/App/Modifier.hs
@@ -122,7 +122,7 @@ appendToDag domainName (DirectoryName appName) (FileName fileName) rawData appCi
 
   let tmpDirPath = Text.concat [ "/", domainName, "/", appName, "/" ]
   let distDirPath = Text.concat [ tmpDirPath, appCidText, "/" ]
-  let filePath = Text.concat [ distDirPath, fileName ]
+  let filePath = Text.concat [ distDirPath, "uploads/", fileName ]
 
   IPFS.Files.cp (Left appCid) (Text.unpack tmpDirPath)
   IPFS.Files.write (Text.unpack filePath) rawData

--- a/fission-web-server/library/Fission/Web/Server/App/Modifier/Class.hs
+++ b/fission-web-server/library/Fission/Web/Server/App/Modifier/Class.hs
@@ -18,6 +18,7 @@ import           Fission.Prelude                                    hiding (on)
 import           Fission.Error                                      as Error
 import           Fission.URL
 
+import qualified Fission.Web.Server.IPFS.DNSLink.Class              as DNSLink
 import           Fission.Web.Server.Error.ActionNotAuthorized.Types
 import           Fission.Web.Server.Models
 import           Fission.Web.Server.MonadDB.Types (Transaction)
@@ -37,6 +38,7 @@ type Errors' = OpenUnion
    , IPFS.Pin.Error
    , IPFS.Stat.Error
 
+   , DNSLink.Errors'
    , ServerError
    , InvalidURL
    ]

--- a/fission-web-server/library/Fission/Web/Server/Error/Class.hs
+++ b/fission-web-server/library/Fission/Web/Server/Error/Class.hs
@@ -11,6 +11,7 @@ import qualified Network.IPFS.Error                                 as IPFS
 import           Network.IPFS.Types
 
 import qualified Network.IPFS.Add.Error                             as Add
+import qualified Network.IPFS.Files.Error                           as Files
 import qualified Network.IPFS.Get.Error                             as Get
 import qualified Network.IPFS.Peer.Error                            as Peer
 
@@ -84,6 +85,7 @@ instance ToServerError Int where
 instance ToServerError IPFS.Error where
   toServerError = \case
     IPFS.AddErr           addErr -> toServerError addErr
+    IPFS.FilesErr         filErr -> toServerError filErr
     IPFS.GetErr           getErr -> toServerError getErr
     IPFS.LinearizationErr linErr -> toServerError linErr
 
@@ -114,6 +116,11 @@ instance ToServerError Add.Error where
     Add.RecursiveAddErr  _ -> err502 { errBody = "Error while adding directory" }
     Add.UnexpectedOutput _ -> err502 { errBody = "Unexpected IPFS result" }
     Add.IPFSDaemonErr  msg -> err502 { errBody = "IPFS Daemon Error: " <> displayLazyBS msg}
+
+instance ToServerError Files.Error where
+  toServerError = \err -> case err of
+    Files.DestinationAlreadyExists -> err422 { errBody = displayLazyBS err }
+    _                              -> err502 { errBody = displayLazyBS err }
 
 instance ToServerError Peer.Error where
   toServerError = \case

--- a/fission-web-server/library/Fission/Web/Server/Handler/Append.hs
+++ b/fission-web-server/library/Fission/Web/Server/Handler/Append.hs
@@ -1,23 +1,37 @@
 module Fission.Web.Server.Handler.Append (handlerV2) where
 
-import           Network.IPFS.File.Types                as File
+import           Network.IPFS.File.Types                            as File
+import           Network.IPFS.Local.Class (MonadLocalIPFS)
+import           Network.IPFS.Remote.Class (MonadRemoteIPFS)
 
 import           Servant
 import           Servant.Server.Generic
 
 import           Fission.Prelude
 
-import qualified Fission.Web.API.Append.Types           as Append
+import qualified Fission.Web.API.Append.Types                       as Append
 
+import           Fission.Web.Server.App.Modifier                    as App
+import           Fission.Web.Server.App.Retriever.Class (Retriever)
 import           Fission.Web.Server.Authorization.Types
-
+import           Fission.Web.Server.Config.Types
+import           Fission.Web.Server.Error                           as Web.Err
+import           Fission.Web.Server.MonadDB.Class (MonadDB(..))
 
 
 handlerV2 ::
-  ( MonadLogger m
+  ( Modifier t
+  , MonadRemoteIPFS m
+  , MonadDB t m
+  , MonadLogger m
+  , MonadReader Config m
+  , MonadTime m
+  , MonadThrow m
+  , Retriever m
   )
   => Append.RoutesV2 (AsServerT m)
 handlerV2 = Append.RoutesV2 {append}
   where
-    append appName fileName (Serialized rawData) Authorization {about = Entity userId _} =
+    append appName fileName (Serialized rawData) Authorization {about = Entity userId _} = do
+      Web.Err.ensureM $ App.addFile userId appName fileName rawData
       return NoContent

--- a/fission-web-server/library/Fission/Web/Server/Handler/Append.hs
+++ b/fission-web-server/library/Fission/Web/Server/Handler/Append.hs
@@ -1,7 +1,7 @@
 module Fission.Web.Server.Handler.Append (handlerV2) where
 
+import           Fission.Web.Server.IPFS.DNSLink.Class
 import           Network.IPFS.File.Types                            as File
-import           Network.IPFS.Local.Class (MonadLocalIPFS)
 import           Network.IPFS.Remote.Class (MonadRemoteIPFS)
 
 import           Servant
@@ -11,23 +11,27 @@ import           Fission.Prelude
 
 import qualified Fission.Web.API.Append.Types                       as Append
 
+import           Fission.Web.Server.App.Domain.Retriever            as App.Domain
 import           Fission.Web.Server.App.Modifier                    as App
-import           Fission.Web.Server.App.Retriever.Class (Retriever)
+import           Fission.Web.Server.App.Retriever.Class             as App
 import           Fission.Web.Server.Authorization.Types
+import qualified Fission.Web.Server.Domain.Retriever.Class          as Domain
 import           Fission.Web.Server.Config.Types
 import           Fission.Web.Server.Error                           as Web.Err
 import           Fission.Web.Server.MonadDB.Class (MonadDB(..))
 
 
 handlerV2 ::
-  ( Modifier t
+  ( App.Domain.Retriever m
+  , App.Modifier t
+  , App.Retriever m
+  , Domain.Retriever m
   , MonadRemoteIPFS m
   , MonadDB t m
+  , MonadDNSLink m
   , MonadLogger m
   , MonadReader Config m
   , MonadTime m
-  , MonadThrow m
-  , Retriever m
   )
   => Append.RoutesV2 (AsServerT m)
 handlerV2 = Append.RoutesV2 {append}

--- a/fission-web-server/library/Fission/Web/Server/Handler/Append.hs
+++ b/fission-web-server/library/Fission/Web/Server/Handler/Append.hs
@@ -37,5 +37,5 @@ handlerV2 ::
 handlerV2 = Append.RoutesV2 {append}
   where
     append appName fileName (Serialized rawData) Authorization {about = Entity userId _} = do
-      Web.Err.ensureM $ App.addFile userId appName fileName rawData
-      return NoContent
+      cid <- Web.Err.ensureM $ App.addFile userId appName fileName rawData
+      return cid

--- a/fission-web-server/library/Fission/Web/Server/Types.hs
+++ b/fission-web-server/library/Fission/Web/Server/Types.hs
@@ -109,6 +109,7 @@ import           Fission.Web.Server.Auth.Token.Basic.Class
 import           Fission.Web.Server.Relay.Store.Class
 
 import           Fission.Web.Server.Config.Types
+import Fission.Web.Server.App.Domain (AlreadyAssociated(maybeSubdomain))
 
 -- | The top-level app type
 newtype Server a = Server { unServer :: RIO Config a }
@@ -546,6 +547,12 @@ instance MonadAuth Authorization Server where
 instance App.Domain.Initializer Server where
   initial = asks baseAppDomain
 
+instance App.Domain.Retriever Server where
+  allForOwner         userId                    = runDB $ App.Domain.allForOwner userId
+  allForApp           appId                     = runDB $ App.Domain.allForApp appId
+  allSiblingsByDomain domainName maybeSubdomain = runDB $ App.Domain.allSiblingsByDomain domainName maybeSubdomain
+  primarySibling      userId url                = runDB $ App.Domain.primarySibling userId url
+
 instance App.Content.Initializer Server where
   placeholder = asks appPlaceholder
 
@@ -906,4 +913,3 @@ runUserUpdate updateDB dbValToTxt uID subdomain =
           PowerDNS.set TXT url (textDisplay zoneID) segments 10 >>= \case
             Left serverErr -> return $ Error.openLeft serverErr
             Right _        -> return $ Right dbVal
-

--- a/ipfs/library/Network/IPFS/Client.hs
+++ b/ipfs/library/Network/IPFS/Client.hs
@@ -32,6 +32,7 @@ import qualified Network.IPFS.Client.DAG.Put.Types               as DAG.Put
 import qualified Network.IPFS.Client.DAG.Types                   as DAG
 import qualified Network.IPFS.Client.Files                       as Files
 import qualified Network.IPFS.Client.Files.Statistics.Types      as Files.Statistics
+import qualified Network.IPFS.Client.Files.Write.Form.Types      as Files.Write
 import qualified Network.IPFS.Client.Pin                         as Pin
 import qualified Network.IPFS.Client.Stat                        as Stat
 
@@ -64,7 +65,7 @@ filesStat     :: Text                                 -> ClientM Files.Statistic
 filesWrite
   :: Text -> Bool -> Bool -> Bool
   -> Maybe Bool -> Maybe Integer -> Maybe Text
-  -> Lazy.ByteString
+  -> (Lazy.ByteString, Files.Write.Form)
   -> ClientM ()
 
 add :<|> cat

--- a/ipfs/library/Network/IPFS/Client.hs
+++ b/ipfs/library/Network/IPFS/Client.hs
@@ -5,7 +5,7 @@ module Network.IPFS.Client
   , dagPut
   , filesCopy
   , filesRemove
-  , filesStatCid
+  , filesStat
   , filesWrite
   , pin
   , stat
@@ -59,7 +59,7 @@ unpin         :: CID -> Bool                          -> ClientM Pin.Response
 
 filesCopy     :: Text -> Text -> Bool                 -> ClientM ()
 filesRemove   :: Text -> Bool -> Maybe Bool           -> ClientM ()
-filesStatCid  :: Text -> Bool                         -> ClientM Files.Statistics.CidResponse
+filesStat     :: Text                                 -> ClientM Files.Statistics.Response
 
 filesWrite
   :: Text -> Bool -> Bool -> Bool
@@ -72,6 +72,6 @@ add :<|> cat
     :<|> stat
 
     :<|> (pin :<|> unpin)
-    :<|> (filesCopy :<|> filesRemove :<|> filesStatCid :<|> filesWrite)
+    :<|> (filesCopy :<|> filesRemove :<|> filesStat :<|> filesWrite)
 
     = client (Proxy @API :: Proxy API)

--- a/ipfs/library/Network/IPFS/Client/Files.hs
+++ b/ipfs/library/Network/IPFS/Client/Files.hs
@@ -1,6 +1,5 @@
 module Network.IPFS.Client.Files
   ( API
-  , module Statistics
   ) where
 
 import           Servant.API

--- a/ipfs/library/Network/IPFS/Client/Files.hs
+++ b/ipfs/library/Network/IPFS/Client/Files.hs
@@ -7,8 +7,8 @@ import           Servant.API
 
 import qualified Network.IPFS.Client.Files.Copy.Types as Copy
 import qualified Network.IPFS.Client.Files.Remove.Types as Remove
-import           Network.IPFS.Client.Files.Statistics.Types as Statistics
+import qualified Network.IPFS.Client.Files.Statistics.Types as Statistics
 import qualified Network.IPFS.Client.Files.Write.Types as Write
 
 
-type API = Copy.API :<|> Remove.API :<|> Statistics.CidAPI :<|> Write.API
+type API = Copy.API :<|> Remove.API :<|> Statistics.API :<|> Write.API

--- a/ipfs/library/Network/IPFS/Client/Files.hs
+++ b/ipfs/library/Network/IPFS/Client/Files.hs
@@ -1,0 +1,14 @@
+module Network.IPFS.Client.Files
+  ( API
+  , module Statistics
+  ) where
+
+import           Servant.API
+
+import qualified Network.IPFS.Client.Files.Copy.Types as Copy
+import qualified Network.IPFS.Client.Files.Remove.Types as Remove
+import           Network.IPFS.Client.Files.Statistics.Types as Statistics
+import qualified Network.IPFS.Client.Files.Write.Types as Write
+
+
+type API = Copy.API :<|> Remove.API :<|> Statistics.CidAPI :<|> Write.API

--- a/ipfs/library/Network/IPFS/Client/Files/Copy/Types.hs
+++ b/ipfs/library/Network/IPFS/Client/Files/Copy/Types.hs
@@ -1,0 +1,12 @@
+module Network.IPFS.Client.Files.Copy.Types (API) where
+
+import           Servant.API
+import           Network.IPFS.Prelude
+
+
+type API
+  = "cp"
+    :> QueryParam' '[Required] "arg" Text -- from
+    :> QueryParam' '[Required] "arg" Text -- to
+    :> QueryParam' '[Required] "parents" Bool
+    :> Post '[JSON] ()

--- a/ipfs/library/Network/IPFS/Client/Files/Remove/Types.hs
+++ b/ipfs/library/Network/IPFS/Client/Files/Remove/Types.hs
@@ -1,0 +1,12 @@
+module Network.IPFS.Client.Files.Remove.Types (API) where
+
+import           Servant.API
+import           Network.IPFS.Prelude
+
+
+type API
+  = "rm"
+    :> QueryParam' '[Required] "arg" Text -- path
+    :> QueryParam' '[Required] "recursive" Bool
+    :> QueryParam' '[] "force" Bool
+    :> Post '[JSON] ()

--- a/ipfs/library/Network/IPFS/Client/Files/Statistics/Types.hs
+++ b/ipfs/library/Network/IPFS/Client/Files/Statistics/Types.hs
@@ -1,4 +1,4 @@
-module Network.IPFS.Client.Files.Statistics.Types (CidAPI, CidResponse (..)) where
+module Network.IPFS.Client.Files.Statistics.Types (API, Response (..)) where
 
 import           Servant.API
 
@@ -6,17 +6,18 @@ import           Network.IPFS.CID.Types
 import           Network.IPFS.Prelude
 
 
-type CidAPI
+type API
   = "stat"
     :> QueryParam' '[Required] "arg" Text -- path
-    :> QueryParam' '[Required] "hash" Bool -- must be true
-    :> Post '[JSON] CidResponse
+    :> Post '[JSON] Response
 
-newtype CidResponse = CidResponse CID
+newtype Response = Response { cid :: CID }
   deriving (Eq, Show)
 
-instance Display CidResponse where
-  textDisplay (CidResponse cid) = textDisplay cid
+instance Display Response where
+  textDisplay (Response cid) = textDisplay cid
 
-instance FromJSON CidResponse where
-  parseJSON = withText "Stat Response" (return . CidResponse . mkCID)
+instance FromJSON Response where
+  parseJSON = withObject "IPFS.Files.Stat.Response" \obj -> do
+    cid <- obj .: "Hash"
+    return $ Response cid

--- a/ipfs/library/Network/IPFS/Client/Files/Statistics/Types.hs
+++ b/ipfs/library/Network/IPFS/Client/Files/Statistics/Types.hs
@@ -1,0 +1,22 @@
+module Network.IPFS.Client.Files.Statistics.Types (CidAPI, CidResponse (..)) where
+
+import           Servant.API
+
+import           Network.IPFS.CID.Types
+import           Network.IPFS.Prelude
+
+
+type CidAPI
+  = "stat"
+    :> QueryParam' '[Required] "arg" Text -- path
+    :> QueryParam' '[Required] "hash" Bool -- must be true
+    :> Post '[JSON] CidResponse
+
+newtype CidResponse = CidResponse CID
+  deriving (Eq, Show)
+
+instance Display CidResponse where
+  textDisplay (CidResponse cid) = textDisplay cid
+
+instance FromJSON CidResponse where
+  parseJSON = withText "Stat Response" (return . CidResponse . mkCID)

--- a/ipfs/library/Network/IPFS/Client/Files/Write/Form/Types.hs
+++ b/ipfs/library/Network/IPFS/Client/Files/Write/Form/Types.hs
@@ -1,0 +1,23 @@
+module Network.IPFS.Client.Files.Write.Form.Types (Form (..)) where
+
+import           RIO
+import qualified RIO.ByteString.Lazy     as Lazy
+
+import           Servant.Multipart
+import           Servant.Multipart.API
+
+import qualified Network.IPFS.File.Types as File
+
+data Form = Form
+  { content :: File.Serialized
+  }
+
+instance ToMultipart Tmp Form where
+  toMultipart Form { content = File.Serialized fileLBS } =
+    MultipartData
+        [ Input
+          { iName  = "data"
+          , iValue = decodeUtf8Lenient $ Lazy.toStrict fileLBS
+          }
+        ]
+        []

--- a/ipfs/library/Network/IPFS/Client/Files/Write/Form/Types.hs
+++ b/ipfs/library/Network/IPFS/Client/Files/Write/Form/Types.hs
@@ -1,23 +1,25 @@
 module Network.IPFS.Client.Files.Write.Form.Types (Form (..)) where
 
 import           RIO
-import qualified RIO.ByteString.Lazy     as Lazy
 
 import           Servant.Multipart
 import           Servant.Multipart.API
 
+import           Network.Mime
 import qualified Network.IPFS.File.Types as File
 
-newtype Form = Form
+data Form = Form
   { content :: File.Serialized
+  , fileName :: FileName
   }
 
-instance ToMultipart Tmp Form where
-  toMultipart Form { content = File.Serialized fileLBS } =
+instance ToMultipart Mem Form where
+  toMultipart Form { content = File.Serialized fileLBS, fileName } =
     MultipartData
-        [ Input
-          { iName  = "data"
-          , iValue = decodeUtf8Lenient $ Lazy.toStrict fileLBS
-          }
-        ]
-        []
+      []
+      [ FileData
+          "data"
+          fileName
+          (decodeUtf8Lenient $ defaultMimeLookup fileName)
+          fileLBS
+      ]

--- a/ipfs/library/Network/IPFS/Client/Files/Write/Form/Types.hs
+++ b/ipfs/library/Network/IPFS/Client/Files/Write/Form/Types.hs
@@ -8,7 +8,7 @@ import           Servant.Multipart.API
 
 import qualified Network.IPFS.File.Types as File
 
-data Form = Form
+newtype Form = Form
   { content :: File.Serialized
   }
 

--- a/ipfs/library/Network/IPFS/Client/Files/Write/Types.hs
+++ b/ipfs/library/Network/IPFS/Client/Files/Write/Types.hs
@@ -1,0 +1,20 @@
+module Network.IPFS.Client.Files.Write.Types (API) where
+
+import           Servant.API
+
+import qualified RIO.ByteString.Lazy as Lazy
+
+import           Network.IPFS.Prelude
+
+
+type API
+  = "write"
+    :> QueryParam' '[Required] "arg" Text         -- path
+    :> QueryParam' '[Required] "create" Bool
+    :> QueryParam' '[Required] "parents" Bool
+    :> QueryParam' '[Required] "truncate" Bool
+    :> QueryParam' '[] "raw-leaves" Bool          -- (experimental) Use raw blocks for newly created leaf nodes.
+    :> QueryParam' '[] "cid-version" Integer      -- (experimental) Cid version to use.
+    :> QueryParam' '[] "hash" Text                -- (experimental) Hash function to use.
+    :> ReqBody '[OctetStream] Lazy.ByteString
+    :> Post '[JSON] ()

--- a/ipfs/library/Network/IPFS/Client/Files/Write/Types.hs
+++ b/ipfs/library/Network/IPFS/Client/Files/Write/Types.hs
@@ -3,8 +3,6 @@ module Network.IPFS.Client.Files.Write.Types (API) where
 import           Servant.API
 import           Servant.Multipart
 
-import qualified RIO.ByteString.Lazy as Lazy
-
 import           Network.IPFS.Prelude
 import           Network.IPFS.Client.Files.Write.Form.Types
 
@@ -18,5 +16,5 @@ type API
     :> QueryParam' '[] "raw-leaves" Bool          -- (experimental) Use raw blocks for newly created leaf nodes.
     :> QueryParam' '[] "cid-version" Integer      -- (experimental) Cid version to use.
     :> QueryParam' '[] "hash" Text                -- (experimental) Hash function to use.
-    :> MultipartForm Tmp Form
+    :> MultipartForm Mem Form
     :> Post '[JSON] ()

--- a/ipfs/library/Network/IPFS/Client/Files/Write/Types.hs
+++ b/ipfs/library/Network/IPFS/Client/Files/Write/Types.hs
@@ -1,10 +1,12 @@
 module Network.IPFS.Client.Files.Write.Types (API) where
 
 import           Servant.API
+import           Servant.Multipart
 
 import qualified RIO.ByteString.Lazy as Lazy
 
 import           Network.IPFS.Prelude
+import           Network.IPFS.Client.Files.Write.Form.Types
 
 
 type API
@@ -16,5 +18,5 @@ type API
     :> QueryParam' '[] "raw-leaves" Bool          -- (experimental) Use raw blocks for newly created leaf nodes.
     :> QueryParam' '[] "cid-version" Integer      -- (experimental) Cid version to use.
     :> QueryParam' '[] "hash" Text                -- (experimental) Hash function to use.
-    :> ReqBody '[OctetStream] Lazy.ByteString
+    :> MultipartForm Tmp Form
     :> Post '[JSON] ()

--- a/ipfs/library/Network/IPFS/Error.hs
+++ b/ipfs/library/Network/IPFS/Error.hs
@@ -6,11 +6,13 @@ module Network.IPFS.Error
 import           Network.IPFS.Prelude
 import           Network.IPFS.Types
 
-import qualified Network.IPFS.Add.Error as Add
-import qualified Network.IPFS.Get.Error as Get
+import qualified Network.IPFS.Add.Error     as Add
+import qualified Network.IPFS.Files.Error   as Files
+import qualified Network.IPFS.Get.Error     as Get
 
 data Error
   = AddErr Add.Error
+  | FilesErr Files.Error
   | GetErr Get.Error
   | LinearizationErr Linearization
   deriving ( Exception

--- a/ipfs/library/Network/IPFS/Files.hs
+++ b/ipfs/library/Network/IPFS/Files.hs
@@ -52,7 +52,7 @@ cp cidOrFilePath destination =
 
     Left err -> do
       formattedError <- parseClientError err
-      return <| Left formattedError
+      return $ Left formattedError
 
 
 {-| MFS Removing.
@@ -73,7 +73,7 @@ rm path =
 
     Left err -> do
       formattedError <- parseClientError err
-      return <| Left formattedError
+      return $ Left formattedError
 
 
 {-| MFS CID for path.
@@ -94,7 +94,7 @@ statCID path =
 
     Left err -> do
       formattedError <- parseClientError err
-      return <| Left formattedError
+      return $ Left formattedError
 
 
 {-| MFS Writing.
@@ -127,7 +127,7 @@ write path raw =
 
     Left err -> do
       formattedError <- parseClientError err
-      return <| Left formattedError
+      return $ Left formattedError
 
 
 
@@ -138,18 +138,18 @@ write path raw =
 -}
 parseClientError :: MonadLogger m => ClientError -> m Error
 parseClientError err = do
-  logError <| displayShow err
-  return <| case err of
+  logError $ displayShow err
+  return $ case err of
     FailureResponse _ response ->
       response
         |> responseBody
         |> decode
         |> \case
           Just IPFS.ErrorBody {message} ->
-            IPFSDaemonErr <| UTF8.textShow message
+            IPFSDaemonErr $ UTF8.textShow message
 
           _ ->
-            UnexpectedOutput <| UTF8.textShow err
+            UnexpectedOutput $ UTF8.textShow err
 
     unknownClientError ->
-      UnknownFilesErr <| UTF8.textShow unknownClientError
+      UnknownFilesErr $ UTF8.textShow unknownClientError

--- a/ipfs/library/Network/IPFS/Files.hs
+++ b/ipfs/library/Network/IPFS/Files.hs
@@ -1,25 +1,21 @@
 module Network.IPFS.Files (cp, rm, statCID, write) where
 
-import           Data.ByteString.Lazy.Char8  as CL
 
-import           Network.IPFS.Client.Files   as Files
 import           Network.IPFS.File.Types
 import           Network.IPFS.Files.Error    as IPFS.Files
 import qualified Network.IPFS.Internal.UTF8  as UTF8
 import           Network.IPFS.Remote.Class   as IPFS
 import           Network.IPFS.Prelude        hiding (link)
-import qualified Network.IPFS.Process.Error  as Process
-import           Network.IPFS.CID.Types      as IPFS ( mkCID, CID(CID) )
 import           Network.IPFS.Types          as IPFS
 
 import qualified Network.IPFS.Client.Files.Statistics.Types as Files.Statistics
 import qualified Network.IPFS.Client.Files.Write.Form.Types as Write
 
 import qualified RIO.ByteString.Lazy         as Lazy
+import           RIO.FilePath
 import qualified RIO.Text                    as Text
 
 import           Servant.Client
-import           Servant.Multipart           as Multipart
 import qualified Servant.Multipart.Client    as Multipart.Client
 
 
@@ -119,9 +115,11 @@ write path raw =
         }
   in do
   boundary <- liftIO Multipart.Client.genBoundary
-  let formData = Serialized raw
 
-  IPFS.mfsWrite args (boundary, Write.Form formData) >>= \case
+  let formData = Serialized raw
+  let fileName = Text.pack $ takeFileName path
+
+  IPFS.mfsWrite args (boundary, Write.Form formData fileName) >>= \case
     Right () ->
       return $ Right ()
 

--- a/ipfs/library/Network/IPFS/Files.hs
+++ b/ipfs/library/Network/IPFS/Files.hs
@@ -1,0 +1,148 @@
+module Network.IPFS.Files (cp, rm, statCID, write) where
+
+import           Data.ByteString.Lazy.Char8  as CL
+
+import           Network.IPFS.Client.Files   as Files
+import           Network.IPFS.Files.Error    as IPFS.Files
+import qualified Network.IPFS.Internal.UTF8  as UTF8
+import           Network.IPFS.Remote.Class   as IPFS
+import           Network.IPFS.Prelude        hiding (link)
+import qualified Network.IPFS.Process.Error  as Process
+import           Network.IPFS.CID.Types      as IPFS ( mkCID, CID(CID) )
+import           Network.IPFS.Types          as IPFS
+
+import qualified Network.IPFS.Client.Files.Statistics.Types as Files.Statistics
+
+import qualified RIO.ByteString.Lazy         as Lazy
+import qualified RIO.Text                    as Text
+
+import           Servant.Client
+
+
+{-| MFS Copying.
+
+Can be used for both copying to and from MFS.
+Will create parent directories.
+
+-}
+cp :: (MonadLogger m, MonadRemoteIPFS m)
+  => Either IPFS.CID FilePath
+  -> FilePath
+  -> m (Either IPFS.Files.Error ())
+cp cidOrFilePath destination =
+  let
+    from =
+      case cidOrFilePath of
+        Left (IPFS.CID hash) -> Text.unpack (Text.append "/ipfs/" hash)
+        Right path           -> path
+
+    args = MfsCopyArgs
+        { from = Text.pack from
+        , to = Text.pack destination
+        , parents = True
+        }
+  in
+  IPFS.mfsCopy args >>= \case
+    Right () ->
+      return $ Right ()
+
+    Left err -> do
+      formattedError <- parseClientError err
+      return <| Left formattedError
+
+
+{-| MFS Removing.
+
+Remove something from MFS.
+
+-}
+rm :: (MonadLogger m, MonadRemoteIPFS m)
+  => FilePath
+  -> m (Either IPFS.Files.Error ())
+rm path =
+  let
+    args = MfsRemoveArgs { path = Text.pack path, recursive = True, force = Nothing }
+  in
+  IPFS.mfsRemove args >>= \case
+    Right () ->
+      return $ Right ()
+
+    Left err -> do
+      formattedError <- parseClientError err
+      return <| Left formattedError
+
+
+{-| MFS CID for path.
+
+Get the CID for a given path.
+
+-}
+statCID :: (MonadLogger m, MonadRemoteIPFS m)
+  => FilePath
+  -> m (Either IPFS.Files.Error IPFS.CID)
+statCID path =
+  let
+    args = MfsStatCidArgs { path = Text.pack path }
+  in
+  IPFS.mfsStatCid args >>= \case
+    Right (Files.Statistics.CidResponse cid) ->
+      return $ Right cid
+
+    Left err -> do
+      formattedError <- parseClientError err
+      return <| Left formattedError
+
+
+{-| MFS Writing.
+
+Write to a file in MFS.
+
+-}
+write :: (MonadLogger m, MonadRemoteIPFS m)
+  => FilePath
+  -> Lazy.ByteString
+  -> m (Either IPFS.Files.Error ())
+write path raw =
+  let
+    args = MfsWriteArgs
+        { path = Text.pack path
+        , create = True
+        , parents = True
+        , truncate = True
+        , rawLeaves = Just True
+        , cidVersion = Just 1
+        , hash = Nothing
+        }
+  in
+  IPFS.mfsWrite args raw >>= \case
+    Right () ->
+      return $ Right ()
+
+    Left err -> do
+      formattedError <- parseClientError err
+      return <| Left formattedError
+
+
+
+-- 🛠
+
+
+{-| Parse and Log the Servant Client Error returned from the IPFS Daemon
+-}
+parseClientError :: MonadLogger m => ClientError -> m Error
+parseClientError err = do
+  logError <| displayShow err
+  return <| case err of
+    FailureResponse _ response ->
+      response
+        |> responseBody
+        |> decode
+        |> \case
+          Just IPFS.ErrorBody {message} ->
+            IPFSDaemonErr <| UTF8.textShow message
+
+          _ ->
+            UnexpectedOutput <| UTF8.textShow err
+
+    unknownClientError ->
+      UnknownFilesErr <| UTF8.textShow unknownClientError

--- a/ipfs/library/Network/IPFS/Files.hs
+++ b/ipfs/library/Network/IPFS/Files.hs
@@ -82,10 +82,10 @@ statCID :: (MonadLogger m, MonadRemoteIPFS m)
   -> m (Either IPFS.Files.Error IPFS.CID)
 statCID path =
   let
-    args = MfsStatCidArgs { path = Text.pack path }
+    args = MfsStatArgs { path = Text.pack path }
   in
-  IPFS.mfsStatCid args >>= \case
-    Right (Files.Statistics.CidResponse cid) ->
+  IPFS.mfsStat args >>= \case
+    Right (Files.Statistics.Response {cid}) ->
       return $ Right cid
 
     Left err -> do

--- a/ipfs/library/Network/IPFS/Files/Error.hs
+++ b/ipfs/library/Network/IPFS/Files/Error.hs
@@ -1,0 +1,57 @@
+module Network.IPFS.Files.Error (Error (..)) where
+
+import           Network.IPFS.Prelude
+import           Network.IPFS.Types
+
+data Error
+  = DestinationAlreadyExists
+  | InvalidCID Text
+  | IPFSDaemonErr Text
+  | UnexpectedOutput Text
+  | UnknownFilesErr Text
+  | TimedOutCopy Natural
+  | TimedOutStat Natural
+  | TimedOutWrite Natural
+  deriving ( Exception
+           , Eq
+           , Generic
+           , Show
+           )
+
+instance Display Error where
+  display = \case
+    DestinationAlreadyExists ->
+      "Cannot copy to destination, item already exists"
+
+    InvalidCID hash ->
+      "Invalid CID: " <> display hash
+
+    IPFSDaemonErr txt ->
+      "IPFS Daemon error: " <> display txt
+
+    TimedOutCopy sec ->
+      mconcat
+        [ "Unable to copy before the timeout of "
+        , display sec
+        , " seconds."
+        ]
+
+    TimedOutStat sec ->
+      mconcat
+        [ "Unable to get statistics before the timeout of "
+        , display sec
+        , " seconds."
+        ]
+
+    TimedOutWrite sec ->
+      mconcat
+        [ "Unable to write before the timeout of "
+        , display sec
+        , " seconds."
+        ]
+
+    UnexpectedOutput txt ->
+      "Unexpected IPFS output: " <> display txt
+
+    UnknownFilesErr txt ->
+      "Unknown IPFS files error: " <> display txt

--- a/ipfs/library/Network/IPFS/Remote/Class.hs
+++ b/ipfs/library/Network/IPFS/Remote/Class.hs
@@ -1,23 +1,47 @@
 module Network.IPFS.Remote.Class
   ( MonadRemoteIPFS
+  , MfsCopyArgs (..)
+  , MfsStatCidArgs (..)
+  , MfsRemoveArgs (..)
+  , MfsWriteArgs (..)
   , runRemote
   , ipfsAdd
   , ipfsCat
   , ipfsStat
   , ipfsPin
   , ipfsUnpin
+  , mfsCopy
+  , mfsRemove
+  , mfsStatCid
+  , mfsWrite
   ) where
 
 import           Network.IPFS.Prelude
 
-import qualified RIO.ByteString.Lazy       as Lazy
+import qualified RIO.ByteString.Lazy                        as Lazy
 import           Servant.Client
 
-import           Network.IPFS.Types        as IPFS
+import           Network.IPFS.Types                         as IPFS
 
-import qualified Network.IPFS.Client       as IPFS.Client
-import qualified Network.IPFS.Client.Pin   as Pin
-import qualified Network.IPFS.File.Types   as File
+import qualified Network.IPFS.Client                        as IPFS.Client
+import qualified Network.IPFS.Client.Pin                    as Pin
+import qualified Network.IPFS.File.Types                    as File
+import qualified Network.IPFS.Client.Files.Statistics.Types as Files.Statistics
+
+
+data MfsCopyArgs = MfsCopyArgs { from :: Text, to :: Text, parents :: Bool }
+data MfsRemoveArgs = MfsRemoveArgs { path :: Text, recursive :: Bool, force :: Maybe Bool }
+data MfsStatCidArgs = MfsStatCidArgs { path :: Text }
+data MfsWriteArgs = MfsWriteArgs
+                      { path :: Text
+                      , create :: Bool
+                      , parents :: Bool
+                      , truncate :: Bool
+                      , rawLeaves :: Maybe Bool
+                      , cidVersion :: Maybe Integer
+                      , hash :: Maybe Text
+                      }
+
 
 class MonadIO m => MonadRemoteIPFS m where
   runRemote :: ClientM a       -> m (Either ClientError a)
@@ -27,9 +51,19 @@ class MonadIO m => MonadRemoteIPFS m where
   ipfsPin   :: CID             -> m (Either ClientError Pin.Response)
   ipfsUnpin :: CID -> Bool     -> m (Either ClientError Pin.Response)
 
+  mfsCopy     :: MfsCopyArgs                      -> m (Either ClientError ())
+  mfsRemove   :: MfsRemoveArgs                    -> m (Either ClientError ())
+  mfsStatCid  :: MfsStatCidArgs                   -> m (Either ClientError Files.Statistics.CidResponse)
+  mfsWrite    :: MfsWriteArgs -> Lazy.ByteString  -> m (Either ClientError ())
+
   -- defaults
-  ipfsAdd   raw           = runRemote $ IPFS.Client.add raw
+  ipfsAdd   raw           = runRemote $ IPFS.Client.add   raw
   ipfsCat   cid           = runRemote $ IPFS.Client.cat   cid
   ipfsPin   cid           = runRemote $ IPFS.Client.pin   cid
   ipfsUnpin cid recursive = runRemote $ IPFS.Client.unpin cid recursive
   ipfsStat  cid           = runRemote $ IPFS.Client.stat  cid
+
+  mfsCopy (MfsCopyArgs { .. })        = runRemote $ IPFS.Client.filesCopy from to parents
+  mfsRemove (MfsRemoveArgs { .. })    = runRemote $ IPFS.Client.filesRemove path recursive force
+  mfsStatCid (MfsStatCidArgs { .. })  = runRemote $ IPFS.Client.filesStatCid path True
+  mfsWrite (MfsWriteArgs { .. }) raw  = runRemote $ IPFS.Client.filesWrite path create parents truncate rawLeaves cidVersion hash raw

--- a/ipfs/library/Network/IPFS/Remote/Class.hs
+++ b/ipfs/library/Network/IPFS/Remote/Class.hs
@@ -1,7 +1,7 @@
 module Network.IPFS.Remote.Class
   ( MonadRemoteIPFS
   , MfsCopyArgs (..)
-  , MfsStatCidArgs (..)
+  , MfsStatArgs (..)
   , MfsRemoveArgs (..)
   , MfsWriteArgs (..)
   , runRemote
@@ -12,7 +12,7 @@ module Network.IPFS.Remote.Class
   , ipfsUnpin
   , mfsCopy
   , mfsRemove
-  , mfsStatCid
+  , mfsStat
   , mfsWrite
   ) where
 
@@ -31,7 +31,7 @@ import qualified Network.IPFS.Client.Files.Statistics.Types as Files.Statistics
 
 data MfsCopyArgs = MfsCopyArgs { from :: Text, to :: Text, parents :: Bool }
 data MfsRemoveArgs = MfsRemoveArgs { path :: Text, recursive :: Bool, force :: Maybe Bool }
-data MfsStatCidArgs = MfsStatCidArgs { path :: Text }
+data MfsStatArgs = MfsStatArgs { path :: Text }
 data MfsWriteArgs = MfsWriteArgs
                       { path :: Text
                       , create :: Bool
@@ -53,7 +53,7 @@ class MonadIO m => MonadRemoteIPFS m where
 
   mfsCopy     :: MfsCopyArgs                      -> m (Either ClientError ())
   mfsRemove   :: MfsRemoveArgs                    -> m (Either ClientError ())
-  mfsStatCid  :: MfsStatCidArgs                   -> m (Either ClientError Files.Statistics.CidResponse)
+  mfsStat     :: MfsStatArgs                      -> m (Either ClientError Files.Statistics.Response)
   mfsWrite    :: MfsWriteArgs -> Lazy.ByteString  -> m (Either ClientError ())
 
   -- defaults
@@ -65,5 +65,5 @@ class MonadIO m => MonadRemoteIPFS m where
 
   mfsCopy (MfsCopyArgs { .. })        = runRemote $ IPFS.Client.filesCopy from to parents
   mfsRemove (MfsRemoveArgs { .. })    = runRemote $ IPFS.Client.filesRemove path recursive force
-  mfsStatCid (MfsStatCidArgs { .. })  = runRemote $ IPFS.Client.filesStatCid path True
+  mfsStat (MfsStatArgs { .. })        = runRemote $ IPFS.Client.filesStat path
   mfsWrite (MfsWriteArgs { .. }) raw  = runRemote $ IPFS.Client.filesWrite path create parents truncate rawLeaves cidVersion hash raw

--- a/ipfs/library/Network/IPFS/Remote/Class.hs
+++ b/ipfs/library/Network/IPFS/Remote/Class.hs
@@ -27,6 +27,7 @@ import qualified Network.IPFS.Client                        as IPFS.Client
 import qualified Network.IPFS.Client.Pin                    as Pin
 import qualified Network.IPFS.File.Types                    as File
 import qualified Network.IPFS.Client.Files.Statistics.Types as Files.Statistics
+import qualified Network.IPFS.Client.Files.Write.Form.Types as Files.Write
 
 
 data MfsCopyArgs = MfsCopyArgs { from :: Text, to :: Text, parents :: Bool }
@@ -51,10 +52,10 @@ class MonadIO m => MonadRemoteIPFS m where
   ipfsPin   :: CID             -> m (Either ClientError Pin.Response)
   ipfsUnpin :: CID -> Bool     -> m (Either ClientError Pin.Response)
 
-  mfsCopy     :: MfsCopyArgs                      -> m (Either ClientError ())
-  mfsRemove   :: MfsRemoveArgs                    -> m (Either ClientError ())
-  mfsStat     :: MfsStatArgs                      -> m (Either ClientError Files.Statistics.Response)
-  mfsWrite    :: MfsWriteArgs -> Lazy.ByteString  -> m (Either ClientError ())
+  mfsCopy     :: MfsCopyArgs                                          -> m (Either ClientError ())
+  mfsRemove   :: MfsRemoveArgs                                        -> m (Either ClientError ())
+  mfsStat     :: MfsStatArgs                                          -> m (Either ClientError Files.Statistics.Response)
+  mfsWrite    :: MfsWriteArgs -> (Lazy.ByteString, Files.Write.Form)  -> m (Either ClientError ())
 
   -- defaults
   ipfsAdd   raw           = runRemote $ IPFS.Client.add   raw

--- a/ipfs/package.yaml
+++ b/ipfs/package.yaml
@@ -88,6 +88,7 @@ dependencies:
   - Glob
   - http-media
   - lens
+  - mime-types
   - monad-logger
   - network-ip
   - regex-compat


### PR DESCRIPTION
This PR implements most of the functionality needed for the HTTP endpoint that appends a file to the DAG of an app.

**Based on the `append-endpoint` branch.**

- Adds various remote IPFS functions for working with the MFS
- Adds a function to add data to the DAG of an app, and another that calls it, and sets the new CID in the database + DNSLink
- Adds some additional info the server readme

This doesn't check for the correct resources in the provided UCAN, that'll be a separate PR.

```http
PUT "http://runfission.test:1337/v2/api/append/app-name/file.name"

Content-Type: application/octet-stream
Authorization: Bearer UCAN

204 No Content
```