### PR TITLE
Bugfix: `fromRawContent` can never succeed

### DIFF
--- a/fission-cli/library/Fission/CLI/Types.hs
+++ b/fission-cli/library/Fission/CLI/Types.hs
@@ -822,7 +822,7 @@ instance
         Left $ CannotResolve cid (ConnectionError $ toException errMsg)
 
       Right (Lazy.toStrict -> resolvedBS) ->
-          Right (UCAN.contentOf (decodeUtf8Lenient resolvedBS))
+        Right resolvedBS
 
 instance MonadEnvironment (FissionCLI errs cfg) where
   getGlobalPath = do

--- a/fission-web-server/library/Fission/Web/Server/Error/Class.hs
+++ b/fission-web-server/library/Fission/Web/Server/Error/Class.hs
@@ -163,7 +163,7 @@ instance ToServerError UCAN.Header.Error where
 instance ToServerError UCAN.Resolver.Error where
   toServerError = \case
     err@(CannotResolve _ _) -> err504 { errBody = displayLazyBS err }
-    err@(InvalidJWT _)      -> err422 { errBody = displayLazyBS err }
+    err@(InvalidJWT _ _)    -> err422 { errBody = displayLazyBS err }
 
 instance ToServerError UCAN.Signature.Error where
   toServerError err = err422 { errBody = displayLazyBS err }
@@ -187,7 +187,7 @@ instance ToServerError UCAN.Claims.Error where
 
 instance ToServerError UCAN.Error where
   toServerError = \case
-    ParseError         -> err400 { errBody = displayLazyBS ParseError }
+    ParseError     err -> err400 { errBody = displayLazyBS $ ParseError err }
     HeaderError    err -> toServerError err
     ClaimsError    err -> toServerError err
     SignatureError err -> toServerError err

--- a/fission-web-server/library/Fission/Web/Server/Types.hs
+++ b/fission-web-server/library/Fission/Web/Server/Types.hs
@@ -557,7 +557,7 @@ instance UCAN.Resolver Server where
         return $ Left $ CannotResolve cid clientErr
 
       Right (Serialized resolvedLBS) ->
-        return $ Right $ UCAN.contentOf $ decodeUtf8Lenient $ Lazy.toStrict resolvedLBS
+        return $ Right $ Lazy.toStrict resolvedLBS
 
 instance ServerDID Server where
   getServerDID = asks fissionDID

--- a/fission-web-server/library/Fission/Web/Server/Types.hs
+++ b/fission-web-server/library/Fission/Web/Server/Types.hs
@@ -41,7 +41,6 @@ import qualified Network.IPFS.Types                        as IPFS
 import qualified Web.DID.Oldstyle.Types                    as DID
 import           Web.DID.Types                             as DID
 
-import qualified Web.UCAN.RawContent                       as UCAN
 import           Web.UCAN.Resolver                         as UCAN
 
 import           Fission.Prelude

--- a/fission-web-server/package.yaml
+++ b/fission-web-server/package.yaml
@@ -1,5 +1,5 @@
 name: fission-web-server
-version: "2.19.0.0"
+version: "2.19.1.0"
 category: API
 author:
   - Brooklyn Zelenka

--- a/hs-ucan/library/Web/UCAN.hs
+++ b/hs-ucan/library/Web/UCAN.hs
@@ -1,25 +1,24 @@
 module Web.UCAN
-  ( fromRawContent
+  ( parse
   , module Web.UCAN.Types
   ) where
 
 import           Data.Aeson
+
 import           RIO
+import qualified RIO.Text as Text
 
 import           Web.UCAN.Resolver.Error as Resolver
 import           Web.UCAN.Types
 
-
-fromRawContent ::
+parse ::
   ( FromJSON fct
   , FromJSON rsc
   , FromJSON ptc
   )
-  => RawContent
+  => ByteString
   -> Either Resolver.Error (UCAN fct rsc ptc)
-fromRawContent rawContent =
-  case decodeStrict rawContentBS of
-    Nothing   -> Left (InvalidJWT rawContentBS)
-    Just ucan -> Right ucan
-  where
-    rawContentBS = encodeUtf8 (unRawContent rawContent)
+parse bs =
+  case eitherDecodeStrict bs of
+    Left reason -> Left $ InvalidJWT (Text.pack reason) bs
+    Right ucan  -> Right ucan

--- a/hs-ucan/library/Web/UCAN/Error.hs
+++ b/hs-ucan/library/Web/UCAN/Error.hs
@@ -8,7 +8,7 @@ import qualified Web.UCAN.Header.Error    as Header
 import qualified Web.UCAN.Signature.Error as Signature
 
 data Error
-  = ParseError
+  = ParseError     Text
   | HeaderError    Header.Error
   | ClaimsError    Claims.Error
   | SignatureError Signature.Error
@@ -22,7 +22,7 @@ instance ToJSON Error where
 
 instance Display Error where
   display = \case
-    ParseError         -> "Could not parse JWT"
+    ParseError     err -> "Could not parse JWT: " <> display err
     HeaderError    err -> "JWT header error: "    <> display err
     SignatureError err -> "JWT signature error: " <> display err
     ClaimsError    err -> "JWT claims error: "    <> display err

--- a/hs-ucan/library/Web/UCAN/Resolver/Class.hs
+++ b/hs-ucan/library/Web/UCAN/Resolver/Class.hs
@@ -4,8 +4,7 @@ import           Network.IPFS.CID.Types
 
 import           RIO
 
-import qualified Web.UCAN.RawContent     as UCAN
 import           Web.UCAN.Resolver.Error as Resolver
 
 class Monad m => Resolver m where
-  resolve :: CID -> m (Either Resolver.Error UCAN.RawContent)
+  resolve :: CID -> m (Either Resolver.Error ByteString)

--- a/hs-ucan/library/Web/UCAN/Resolver/Error.hs
+++ b/hs-ucan/library/Web/UCAN/Resolver/Error.hs
@@ -7,7 +7,7 @@ import           Web.UCAN.Internal.Orphanage.ClientError ()
 
 data Error
   = CannotResolve CID ClientError
-  | InvalidJWT ByteString
+  | InvalidJWT Text ByteString
   deriving (Show, Eq, Exception)
 
 instance Display Error where
@@ -15,5 +15,5 @@ instance Display Error where
     CannotResolve cid err ->
       "Unable to resolve " <> display cid <> " because " <> display err
 
-    InvalidJWT jwtBS ->
-      "Invalid resolved JWT: " <> displayBytesUtf8 jwtBS
+    InvalidJWT reason jwtBS ->
+      "Invalid resolved JWT: " <> display reason <> ", raw input: " <> displayBytesUtf8 jwtBS

--- a/hs-ucan/package.yaml
+++ b/hs-ucan/package.yaml
@@ -1,5 +1,5 @@
 name: hs-ucan
-version: '0.0.1.1'
+version: '0.0.2.0'
 category: API
 author:
   - Brooklyn Zelenka

--- a/hs-ucan/package.yaml
+++ b/hs-ucan/package.yaml
@@ -1,5 +1,5 @@
 name: hs-ucan
-version: '0.0.1.0'
+version: '0.0.1.1'
 category: API
 author:
   - Brooklyn Zelenka


### PR DESCRIPTION
@bgins and I ran into this problem while working on #606. The core thing is that it's impossible to actually construct a UCAN from a `RawContent` without also having a `Signature`, so `fromRawContent` could never succeed.

```haskell
UCAN.RawContent -> Either Resolver.Error (UCAN fct rsc ptc) -- 😾 How get signature?
```

I also bubbled some error content through while I had the hood up.

# TODO

The one thing that isn't covered here is if `UCAN.parse` should automatically add quotes to make the JSON parsing work internally. I think not, but perhaps it would be less surprising with them?