### PR TITLE
Add generate credentials command

### DIFF
--- a/fission-cli/library/Fission/CLI.hs
+++ b/fission-cli/library/Fission/CLI.hs
@@ -38,6 +38,7 @@ import qualified Fission.CLI.App                                    as App
 import           Fission.CLI.Types
 
 import           Fission.CLI.Handler.Error.Types                    (Errs)
+import qualified Fission.CLI.Handler.Generate                       as Generate
 import qualified Fission.CLI.Handler.Setup                          as Setup
 import qualified Fission.CLI.Handler.User                           as User
 
@@ -109,6 +110,9 @@ interpret baseCfg@Base.Config {ipfsDaemonVar} cmd =
 
         User subCmd ->
           User.interpret subCmd
+
+        Generate subCmd ->
+          Generate.interpret subCmd
 
 finalizeDID :: MonadIO m => Maybe DID -> Base.Config -> m (Either (OpenUnion Errs) DID)
 finalizeDID (Just did) _ =

--- a/fission-cli/library/Fission/CLI/Handler.hs
+++ b/fission-cli/library/Fission/CLI/Handler.hs
@@ -3,6 +3,8 @@ module Fission.CLI.Handler
   , module Fission.CLI.Handler.App.Init
   , module Fission.CLI.Handler.App.Publish
   --
+  , module Fission.CLI.Handler.Generate.Credentials
+  --
   , module Fission.CLI.Handler.User.Login
   , module Fission.CLI.Handler.User.Register
   , module Fission.CLI.Handler.User.Whoami
@@ -11,6 +13,8 @@ module Fission.CLI.Handler
 import           Fission.CLI.Handler.App.Info
 import           Fission.CLI.Handler.App.Init
 import           Fission.CLI.Handler.App.Publish
+--
+import           Fission.CLI.Handler.Generate.Credentials
 --
 import           Fission.CLI.Handler.User.Login
 import           Fission.CLI.Handler.User.Register

--- a/fission-cli/library/Fission/CLI/Handler/Generate.hs
+++ b/fission-cli/library/Fission/CLI/Handler/Generate.hs
@@ -15,8 +15,7 @@ import           Fission.CLI.Handler.Error.Types           (Errs)
 interpret ::
   ( Contains Errs errs
   , Contains errs errs
-  , Display   (OpenUnion errs)
-  , Exception (OpenUnion errs)
+  , Display  (OpenUnion errs)
   )
   => Generate.Options
   -> FissionCLI errs Base.Config ()

--- a/fission-cli/library/Fission/CLI/Handler/Generate.hs
+++ b/fission-cli/library/Fission/CLI/Handler/Generate.hs
@@ -24,5 +24,5 @@ interpret cmd = do
   logDebug @Text "Generate interpreter"
 
   case cmd of
-    Credentials _ -> do
+    Credentials _ ->
       Handler.credentials

--- a/fission-cli/library/Fission/CLI/Handler/Generate.hs
+++ b/fission-cli/library/Fission/CLI/Handler/Generate.hs
@@ -26,4 +26,3 @@ interpret cmd = do
   case cmd of
     Credentials _ -> do
       Handler.credentials
-      return ()

--- a/fission-cli/library/Fission/CLI/Handler/Generate.hs
+++ b/fission-cli/library/Fission/CLI/Handler/Generate.hs
@@ -1,0 +1,29 @@
+module Fission.CLI.Handler.Generate (interpret) where
+
+import           Fission.Prelude
+
+import qualified Fission.CLI.Base.Types                    as Base
+
+import           Fission.CLI.Types
+
+import qualified Fission.CLI.Handler                       as Handler
+
+import           Fission.CLI.Parser.Command.Generate.Types as Generate
+
+import           Fission.CLI.Handler.Error.Types           (Errs)
+
+interpret ::
+  ( Contains Errs errs
+  , Contains errs errs
+  , Display   (OpenUnion errs)
+  , Exception (OpenUnion errs)
+  )
+  => Generate.Options
+  -> FissionCLI errs Base.Config ()
+interpret cmd = do
+  logDebug @Text "Generate interpreter"
+
+  case cmd of
+    Credentials _ -> do
+      Handler.credentials
+      return ()

--- a/fission-cli/library/Fission/CLI/Handler/Generate/Credentials.hs
+++ b/fission-cli/library/Fission/CLI/Handler/Generate/Credentials.hs
@@ -48,4 +48,4 @@ credentials = do
 
   UTF8.putText "🆔 DID: "
   colourized [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Blue] do
-    UTF8.putText $ textDisplay did <> "\n"
+    UTF8.putTextLn $ textDisplay did

--- a/fission-cli/library/Fission/CLI/Handler/Generate/Credentials.hs
+++ b/fission-cli/library/Fission/CLI/Handler/Generate/Credentials.hs
@@ -1,0 +1,33 @@
+-- | Credentials command
+module Fission.CLI.Handler.Generate.Credentials (credentials) where
+
+import qualified RIO.Text                                  as Text
+
+import qualified Crypto.PubKey.Ed25519                     as Ed25519
+import           Crypto.Random.Types
+
+
+import           Fission.Prelude
+
+import qualified Fission.Internal.UTF8                     as UTF8
+
+import           Fission.CLI.Environment                   as Env
+
+import qualified Fission.CLI.Display.Error                 as CLI.Error
+import qualified Fission.CLI.Display.Success               as CLI.Success
+
+
+-- | The command to generate key pairs and DIDs
+credentials ::
+  ( MonadIO          m
+  , MonadTime        m
+  , MonadLogger      m
+  , MonadEnvironment m
+  , MonadCleanup     m
+  , Show    (ErrorCase m)
+  , Display (ErrorCase m)
+  , CheckErrors m
+  )
+  => m ()
+credentials = do
+  logDebug @Text "Testing the credentials command"

--- a/fission-cli/library/Fission/CLI/Handler/Generate/Credentials.hs
+++ b/fission-cli/library/Fission/CLI/Handler/Generate/Credentials.hs
@@ -1,33 +1,51 @@
 -- | Credentials command
 module Fission.CLI.Handler.Generate.Credentials (credentials) where
 
-import qualified RIO.Text                                  as Text
-
 import qualified Crypto.PubKey.Ed25519                     as Ed25519
 import           Crypto.Random.Types
+
+import qualified System.Console.ANSI                       as ANSI
 
 
 import           Fission.Prelude
 
+import qualified Fission.Key                               as Key
 import qualified Fission.Internal.UTF8                     as UTF8
 
-import           Fission.CLI.Environment                   as Env
+import           Fission.CLI.Display.Text
 
-import qualified Fission.CLI.Display.Error                 as CLI.Error
 import qualified Fission.CLI.Display.Success               as CLI.Success
 
+import           Web.DID.Types                             as DID
+import qualified Web.UCAN.Internal.Base64                  as B64
 
 -- | The command to generate key pairs and DIDs
 credentials ::
   ( MonadIO          m
-  , MonadTime        m
+  , MonadRandom m
   , MonadLogger      m
-  , MonadEnvironment m
   , MonadCleanup     m
-  , Show    (ErrorCase m)
-  , Display (ErrorCase m)
-  , CheckErrors m
   )
   => m ()
 credentials = do
-  logDebug @Text "Testing the credentials command"
+  logDebug @Text "🪄🗝️ Generating a key pair..."
+
+  secretKey <- Ed25519.generateSecretKey
+
+  let 
+    publicKey = Ed25519.toPublic secretKey
+    did = DID.Key $ Key.Ed25519PublicKey publicKey
+
+  CLI.Success.putOk "Generated an Ed25519 key pair and associated DID"
+
+  UTF8.putText "🗝️  Private key: "
+  colourized [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Blue] do
+    UTF8.putTextLn $ decodeUtf8Lenient (B64.toB64ByteString secretKey)
+
+  UTF8.putText "🔑 Public key: "
+  colourized [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Blue] do
+    UTF8.putTextLn $ textDisplay publicKey
+
+  UTF8.putText "🆔 DID: "
+  colourized [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Blue] do
+    UTF8.putText $ textDisplay did <> "\n"

--- a/fission-cli/library/Fission/CLI/Parser/Command.hs
+++ b/fission-cli/library/Fission/CLI/Parser/Command.hs
@@ -11,6 +11,8 @@ import qualified Fission.CLI.Parser.Verbose             as Verbose
 import qualified Fission.CLI.Parser.Command.App         as App
 import qualified Fission.CLI.Parser.Command.App.Up      as App.Up
 
+import qualified Fission.CLI.Parser.Command.Generate    as Generate
+
 import qualified Fission.CLI.Parser.Command.User        as User
 import qualified Fission.CLI.Parser.Command.User.Login  as User.Login
 import qualified Fission.CLI.Parser.Command.User.WhoAmI as User.WhoAmI
@@ -51,7 +53,8 @@ subCommands =
   hsubparser $ mconcat
     [ commandGroup "Command Groups"
     , metavar "COMMAND"
-    , command "app"  $ fmap Command.App  App.parserWithInfo
-    , command "user" $ fmap Command.User User.parserWithInfo
+    , command "app"      $ fmap Command.App      App.parserWithInfo
+    , command "user"     $ fmap Command.User     User.parserWithInfo
+    , command "generate" $ fmap Command.Generate Generate.parserWithInfo
     ]
 

--- a/fission-cli/library/Fission/CLI/Parser/Command/Generate.hs
+++ b/fission-cli/library/Fission/CLI/Parser/Command/Generate.hs
@@ -1,0 +1,27 @@
+module Fission.CLI.Parser.Command.Generate
+  ( parserWithInfo
+  , parser
+  -- * Reexports
+  , module Fission.CLI.Parser.Command.Generate.Types
+  ) where
+
+import           Options.Applicative
+
+import           Fission.Prelude
+
+import           Fission.CLI.Parser.Command.Generate.Types
+import qualified Fission.CLI.Parser.Command.Generate.Credentials as Credentials
+
+parserWithInfo :: ParserInfo Options
+parserWithInfo =
+  parser `info` mconcat
+    [ fullDesc
+    , header   "Generate commands"
+    , progDesc "Generate key pairs and DIDs"
+    ]
+
+parser :: Parser Options
+parser =
+  hsubparser $ mconcat
+    [ command "credentials"    $ fmap Credentials Credentials.parserWithInfo
+    ]

--- a/fission-cli/library/Fission/CLI/Parser/Command/Generate/Credentials.hs
+++ b/fission-cli/library/Fission/CLI/Parser/Command/Generate/Credentials.hs
@@ -16,7 +16,7 @@ parserWithInfo :: ParserInfo Options
 parserWithInfo =
   parser `info` mconcat
     [ fullDesc
-    , progDesc "Generate a key pair and DID"
+    , progDesc "Generate an Ed25519 key pair and an associated DID"
     ]
 
 parser :: Parser Options

--- a/fission-cli/library/Fission/CLI/Parser/Command/Generate/Credentials.hs
+++ b/fission-cli/library/Fission/CLI/Parser/Command/Generate/Credentials.hs
@@ -1,0 +1,23 @@
+module Fission.CLI.Parser.Command.Generate.Credentials
+  ( parserWithInfo
+  , parser
+  -- * Reexports
+  , module Fission.CLI.Parser.Command.Generate.Credentials.Types
+  ) where
+
+import           Options.Applicative
+
+import           Fission.Prelude
+
+import           Fission.CLI.Parser.Command.Generate.Credentials.Types
+
+
+parserWithInfo :: ParserInfo Options
+parserWithInfo =
+  parser `info` mconcat
+    [ fullDesc
+    , progDesc "Generate a key pair and DID"
+    ]
+
+parser :: Parser Options
+parser = pure CommandOnly

--- a/fission-cli/library/Fission/CLI/Parser/Command/Generate/Credentials/Types.hs
+++ b/fission-cli/library/Fission/CLI/Parser/Command/Generate/Credentials/Types.hs
@@ -1,0 +1,6 @@
+module Fission.CLI.Parser.Command.Generate.Credentials.Types (Options (..)) where
+
+import           Fission.Prelude
+
+data Options = CommandOnly
+  deriving (Show, Eq)

--- a/fission-cli/library/Fission/CLI/Parser/Command/Generate/Types.hs
+++ b/fission-cli/library/Fission/CLI/Parser/Command/Generate/Types.hs
@@ -1,0 +1,9 @@
+module Fission.CLI.Parser.Command.Generate.Types (Options (..)) where
+
+import           Fission.Prelude
+
+import qualified Fission.CLI.Parser.Command.Generate.Credentials as Credentials
+
+data Options
+  = Credentials Credentials.Options    -- ^ Generate a key pair and DID
+  deriving (Show, Eq)

--- a/fission-cli/library/Fission/CLI/Parser/Command/Types.hs
+++ b/fission-cli/library/Fission/CLI/Parser/Command/Types.hs
@@ -4,16 +4,18 @@ import qualified RIO.Text                                 as Text
 
 import           Fission.Prelude
 
-import qualified Fission.CLI.Parser.Command.App.Types     as App
-import qualified Fission.CLI.Parser.Command.Setup.Types   as Setup
-import qualified Fission.CLI.Parser.Command.User.Types    as User
-import qualified Fission.CLI.Parser.Command.Version.Types as Version
+import qualified Fission.CLI.Parser.Command.App.Types      as App
+import qualified Fission.CLI.Parser.Command.Generate.Types as Generate
+import qualified Fission.CLI.Parser.Command.Setup.Types    as Setup
+import qualified Fission.CLI.Parser.Command.User.Types     as User
+import qualified Fission.CLI.Parser.Command.Version.Types  as Version
 
 data Command
-  = Version Version.Options
-  | App     App.Options
-  | User    User.Options
-  | Setup   Setup.Options
+  = Version  Version.Options
+  | App      App.Options
+  | User     User.Options
+  | Setup    Setup.Options
+  | Generate Generate.Options
   deriving (Eq, Show)
 
 instance Display Command where

--- a/fission-cli/package.yaml
+++ b/fission-cli/package.yaml
@@ -1,5 +1,5 @@
 name: fission-cli
-version: "2.17.2.0"
+version: "2.18.0.0"
 category: CLI
 author:
   - Brooklyn Zelenka


### PR DESCRIPTION
## Summary

This PR adds a `fission generate credentials` command to create Ed25519 key pairs and their associated DIDs.

This PR fixes/implements the following **bugs/features**

* [x] Add `fission generate credentials` command

The credentials subcommand has no options and only generates Ed25519 key pairs

```
»  ~/.local/bin/fission generate credentials --help
Usage: fission generate credentials 
  Generate an Ed25519 key pair and an associated DID

Available options:
  -h,--help                Show this help text
```

The output prints a private key, public key, and DID

```
»  ~/.local/bin/fission generate credentials
✅ Generated an Ed25519 key pair and associated DID
🗝️  Private key: <private-key>
🔑 Public key: <public-key>
🆔 DID: <DID>
```

This PR also adds a top-level `generate` command with no fallbacks. It must be used with the `credentials` subcommand. The description for the `generate` command in `fission --help` is "Generate key pairs and DIDs".


## Test plan (required)

Compile, then run the `fission credentials generate` command to generate a test key pair and DID.

Check the help text for `fission`, `fission generate` and `fission generate credentials`.

## Closing issues

Closes #613

## Tasks

- [x] Add command stub
- [x] Generate key pair and DIDs and print them at the command line

## After Merge
* [ ] Does this change invalidate any docs or tutorials? No, but we should add docs for it
* [ ] Does this change require a release to be made? Yes, but we should wait for the remainder of the append endpoint functionality before releasing