### PR TITLE
Make email optional at registration

### DIFF
--- a/fission-cli/library/Fission/CLI/Handler/User/Register.hs
+++ b/fission-cli/library/Fission/CLI/Handler/User/Register.hs
@@ -129,7 +129,7 @@ createAccount maybeUsername maybeEmail = do
   let
     form = Registration
       { username
-      , email
+      , email      = Just email
       , password   = Nothing
       , exchangePK = Just exchangePK
       }

--- a/fission-core/library/Fission/User/Registration/Types.hs
+++ b/fission-core/library/Fission/User/Registration/Types.hs
@@ -14,7 +14,7 @@ import           Web.UCAN.Internal.Orphanage.RSA2048.Public ()
 
 data Registration = Registration
   { username   :: Username
-  , email      :: Email
+  , email      :: Maybe Email
   , password   :: Maybe Password
   , exchangePK :: Maybe RSA.PublicKey
   }
@@ -29,16 +29,22 @@ instance Arbitrary Registration where
     return Registration {..}
 
 instance ToJSON Registration where
-  toJSON Registration { username, email = Email email' } =
-    Object [ ("username", String $ textDisplay username)
-           , ("email",    String email')
-           ]
+  toJSON Registration { username, email = mayEmail } =
+    case mayEmail of
+      Just (Email email) ->
+        Object [ ("username", String $ textDisplay username)
+               , ("email",    String email)
+               ]
+
+      Nothing ->
+        Object [ ("username", String $ textDisplay username) ]
+
 
 instance FromJSON Registration where
   parseJSON = withObject "Registration" \obj -> do
     username   <- obj .:  "username"
     password   <- obj .:? "password"
-    email      <- obj .:  "email"
+    email      <- obj .:? "email"
     exchangePK <- obj .:? "exchangePK"
 
     return Registration {..}
@@ -54,11 +60,11 @@ instance ToSchema Registration where
            [ ("username", username')
            , ("email", email')
            ]
-      |> required .~ ["username", "email"]
+      |> required .~ ["username"]
       |> description ?~ "The information that a user needs to provide to login/register."
       |> example ?~ toJSON Registration
            { username   = "username"
-           , email      = "alice@example.com"
+           , email      = Just "alice@example.com"
            , password   = Nothing
            , exchangePK = Nothing
            }

--- a/fission-web-server/library/Fission/Web/Server/Internal/Production.hs
+++ b/fission-web-server/library/Fission/Web/Server/Internal/Production.hs
@@ -223,7 +223,7 @@ start middleware runner = do
     logInfo @Text "🙋 Ensuring default user is in DB"
     userId <- User.getByPublicKey serverPK >>= \case
       Just (Entity userId _) -> return userId
-      Nothing -> Web.Error.ensureM $ User.createDB "fission" serverPK "hello@fission.codes" now
+      Nothing -> Web.Error.ensureM $ User.createDB "fission" serverPK (Just "hello@fission.codes") now
 
     logInfo @Text "💽 Ensuring default data domain domains is in DB"
     Domain.getByDomainName userRootDomain >>= \case

--- a/fission-web-server/library/Fission/Web/Server/User/Creator.hs
+++ b/fission-web-server/library/Fission/Web/Server/User/Creator.hs
@@ -37,10 +37,10 @@ createDB ::
      MonadIO m
   => Username
   -> Key.Public
-  -> Email
+  -> Maybe Email
   -> UTCTime
   -> Transaction m (Either Errors' UserId)
-createDB username pk email now =
+createDB username pk mayEmail now =
   insertUnique user >>= \case
     Just userId -> return $ Right userId
     Nothing     -> determineConflict username (Just pk)
@@ -50,7 +50,7 @@ createDB username pk email now =
         { userPublicKey     = Just pk
         , userExchangeKeys  = Just []
         , userUsername      = username
-        , userEmail         = Just email
+        , userEmail         = mayEmail
         , userRole          = Regular
         , userActive        = True
         , userVerified      = False
@@ -66,10 +66,10 @@ createWithPasswordDB ::
      MonadIO m
   => Username
   -> Password
-  -> Email
+  -> Maybe Email
   -> UTCTime
   -> Transaction m (Either Errors' UserId)
-createWithPasswordDB username password email now =
+createWithPasswordDB username password mayEmail now =
   Password.hashPassword password >>= \case
     Left err ->
       return $ Error.openLeft err
@@ -79,7 +79,7 @@ createWithPasswordDB username password email now =
         { userPublicKey     = Nothing
         , userExchangeKeys  = Just []
         , userUsername      = username
-        , userEmail         = Just email
+        , userEmail         = mayEmail
         , userRole          = Regular
         , userActive        = True
         , userVerified      = False

--- a/fission-web-server/library/Fission/Web/Server/User/Creator/Class.hs
+++ b/fission-web-server/library/Fission/Web/Server/User/Creator/Class.hs
@@ -56,14 +56,14 @@ class Heroku.AddOn.Creator m => Creator m where
   create ::
        Username
     -> Key.Public
-    -> Email
+    -> Maybe Email
     -> UTCTime
     -> m (Either Errors' UserId)
 
   createWithPassword ::
        Username
     -> Password
-    -> Email
+    -> Maybe Email
     -> UTCTime
     -> m (Either Errors' UserId)
 


### PR DESCRIPTION
## Summary

This PR implements the following **features**

* [ ] Makes email optional when registering users

## Test plan (required)

This feature can be tested locally with a `PUT` request to `http://runfission.test:1337/v2/api/user` and a body that looks something like

```json
{
    "username": "testuser"
}
```

The request must be authorized with a bearer token that contains a new user DID as its issuer and the Fission server DID (`did:key:z6MkgYGF3thn8k1Fv4p4dWXKtsXCnLH7q9yw4QgNPULDmDKB`) as its audience.

The test should be repeated a second time with an email in the body

```json
{
    "username": "testuser",
    "email": "example@email.com"
}
```

It's also worth checking that CLI continues to work with these changes.

## Closing issues

Closes #616 

## After Merge
* [x] Does this change invalidate any docs or tutorials? Yes, the API docs are updated as a part of this PR
* [x] Does this change require a release to be made? No, but we will want to deploy the changes to staging for a start
