### PR TITLE
cli: add comma to clarify instructions after app registration

### DIFF
--- a/fission-cli/library/Fission/CLI/Handler/App/Init.hs
+++ b/fission-cli/library/Fission/CLI/Handler/App/Init.hs
@@ -76,7 +76,7 @@ appInit appDir mayBuildDir' mayAppName = do
 
       CLI.Success.putOk $ "App initialized as " <> textDisplay appURL
 
-      UTF8.putText "⏯️  Next run "
+      UTF8.putText "⏯️  Next, run "
 
       colourized [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Blue] do
         UTF8.putText "fission app publish [--open|--watch]"


### PR DESCRIPTION
I was a bit confused and read: "on the next run, use this command instead"
Only to realize I have to do it next to have my app published 😅

## Summary
<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [x] cli text change
