### PR TITLE
Validate UCAN resource

### DIFF
--- a/fission-cli/library/Fission/CLI/Remote.hs
+++ b/fission-cli/library/Fission/CLI/Remote.hs
@@ -1,5 +1,6 @@
 module Fission.CLI.Remote
-  ( getRemoteURL
+  ( getAppDomain
+  , getRemoteURL
   , getRemoteBaseUrl
   , getNameService
   , getIpfsGateway
@@ -16,6 +17,9 @@ import           Fission.URL.Types
 import           Fission.Web.API.Remote
 
 import           Fission.CLI.Remote.Class
+
+getAppDomain :: MonadRemote m => m URL
+getAppDomain = toAppDomain <$> getRemote
 
 getRemoteBaseUrl :: MonadRemote m => m BaseUrl
 getRemoteBaseUrl = toBaseUrl <$> getRemote

--- a/fission-core/library/Fission/Web/Auth/Token/UCAN/Resource/Types.hs
+++ b/fission-core/library/Fission/Web/Auth/Token/UCAN/Resource/Types.hs
@@ -2,7 +2,8 @@ module Fission.Web.Auth.Token.UCAN.Resource.Types (Resource (..)) where
 
 import           Fission.Prelude
 
-import           Fission.URL
+import           Fission.URL.DomainName.Types ( DomainName )
+import           Fission.URL.Types ( URL )
 import           Fission.Web.Auth.Token.UCAN.Resource.Scope.Types
 
 import qualified Data.Bits                                        as Bits

--- a/fission-web-api/library/Fission/Web/API/Remote.hs
+++ b/fission-web-api/library/Fission/Web/API/Remote.hs
@@ -1,6 +1,7 @@
 module Fission.Web.API.Remote
   ( Remote (..)
   , fromText
+  , toAppDomain
   , toBaseUrl
   , toURL
   , toNameService
@@ -50,6 +51,17 @@ fromText txt =
     "dev"         -> pure LocalDev
 
     custom        -> Custom <$> parseBaseUrl (Text.unpack custom)
+
+toAppDomain :: Remote -> URL
+toAppDomain = \case
+  Production -> URL "fission.app"    Nothing
+  Staging    -> URL "fissionapp.net" Nothing
+  LocalDev   -> URL "localhost"      Nothing
+  Custom url ->
+    if Text.isSuffixOf ".test" (textDisplay $ baseUrlHost url) then
+      URL "fissionapp.test" Nothing
+    else
+      URL.fromBaseUrl url
 
 toBaseUrl :: Remote -> BaseUrl
 toBaseUrl = \case

--- a/fission-web-server/library/Fission/Web/Server/App/Modifier/Class.hs
+++ b/fission-web-server/library/Fission/Web/Server/App/Modifier/Class.hs
@@ -23,6 +23,8 @@ import           Fission.Web.Server.Error.ActionNotAuthorized.Types
 import           Fission.Web.Server.Models
 import           Fission.Web.Server.MonadDB.Types (Transaction)
 
+import qualified Fission.Web.Auth.Token.UCAN.Resource.Types         as Ucan
+
 
 type Errors' = OpenUnion
   '[ NotFound App
@@ -33,6 +35,7 @@ type Errors' = OpenUnion
    , ActionNotAuthorized App
    , ActionNotAuthorized AppDomain
    , ActionNotAuthorized URL
+   , ActionNotAuthorized Ucan.Resource
 
    , IPFS.Files.Error
    , IPFS.Pin.Error

--- a/fission-web-server/library/Fission/Web/Server/Handler/Append.hs
+++ b/fission-web-server/library/Fission/Web/Server/Handler/Append.hs
@@ -4,7 +4,6 @@ import           Fission.Web.Server.IPFS.DNSLink.Class
 import           Network.IPFS.File.Types                            as File
 import           Network.IPFS.Remote.Class (MonadRemoteIPFS)
 
-import           Servant
 import           Servant.Server.Generic
 
 import           Fission.Prelude
@@ -36,6 +35,6 @@ handlerV2 ::
   => Append.RoutesV2 (AsServerT m)
 handlerV2 = Append.RoutesV2 {append}
   where
-    append appName fileName (Serialized rawData) Authorization {about = Entity userId _} = do
-      cid <- Web.Err.ensureM $ App.addFile userId appName fileName rawData
+    append appName fileName (Serialized rawData) Authorization {about = Entity userId _, potency, resource} = do
+      cid <- Web.Err.ensureM $ App.addFile userId appName fileName rawData potency resource
       return cid


### PR DESCRIPTION
Checks the resource of the UCAN used with the append endpoint, and fixes the domain name used in the "delegated" UCAN resources.


## Test plan (required)

Using a UCAN with an invalid resource, ie. a `rsc` that doesn't match `{ "app": "DOMAIN_OF_APP" }`, should produce a `403` status.