### PR TITLE
remove nix pure from shell environment

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,6 @@
               wrapProgram $out/bin/stack \
                 --add-flags "\
                   --nix \
-                  --nix-pure \
                   --nix-shell-file=nix/stack-integration.nix \
                 "
             '';


### PR DESCRIPTION
Using stack's nix integration with `--nix-pure` seems to be (sometimes?) creating segfaults in stack specifically on aarch64-darwin. This PR simply removes `--nix-pure` from the stack wrapper.