### PR TITLE
Endpoint user/challenger/recover

### DIFF
--- a/fission-web-api/library/Fission/Web/API/User/Challenge/Types.hs
+++ b/fission-web-api/library/Fission/Web/API/User/Challenge/Types.hs
@@ -1,0 +1,22 @@
+module Fission.Web.API.User.Challenge.Types (Routes (..)) where
+
+-- import           Fission.Challenge.Types
+
+import           Fission.Web.API.Prelude
+
+import           Fission.User.Username.Types
+import qualified Fission.Web.API.Auth.Types  as Auth
+
+data Routes mode = Routes
+  { recover ::
+      mode
+      :- "recover"
+      :> Summary "Return challenge for account recovery"
+      --
+      :> Capture "Username" Username
+      --
+      :> Auth.HigherOrder
+      :> GetNoContent
+      -- :> Post '[JSON] Challenge
+  }
+  deriving Generic

--- a/fission-web-api/library/Fission/Web/API/User/Challenge/Types.hs
+++ b/fission-web-api/library/Fission/Web/API/User/Challenge/Types.hs
@@ -15,7 +15,7 @@ data Routes mode = Routes
       --
       :> Capture "Username" Username
       --
-      -- :> Auth.HigherOrder
+      :> Auth.HigherOrder
       :> Post '[JSON] Challenge
   }
   deriving Generic

--- a/fission-web-api/library/Fission/Web/API/User/Challenge/Types.hs
+++ b/fission-web-api/library/Fission/Web/API/User/Challenge/Types.hs
@@ -4,6 +4,8 @@ import           Fission.Challenge.Types
 
 import           Fission.Web.API.Prelude
 
+import           Fission.User.Username.Types
+
 import qualified Fission.Web.API.Auth.Types  as Auth
 
 data Routes mode = Routes
@@ -11,6 +13,8 @@ data Routes mode = Routes
       mode
       :- "recover"
       :> Summary "Return challenge for account recovery"
+      --
+      :> Capture "Username" Username
       --
       :> Auth.HigherOrder
       :> Post '[JSON] Challenge

--- a/fission-web-api/library/Fission/Web/API/User/Challenge/Types.hs
+++ b/fission-web-api/library/Fission/Web/API/User/Challenge/Types.hs
@@ -1,6 +1,6 @@
 module Fission.Web.API.User.Challenge.Types (Routes (..)) where
 
--- import           Fission.Challenge.Types
+import           Fission.Challenge.Types
 
 import           Fission.Web.API.Prelude
 
@@ -15,8 +15,7 @@ data Routes mode = Routes
       --
       :> Capture "Username" Username
       --
-      :> Auth.HigherOrder
-      :> GetNoContent
-      -- :> Post '[JSON] Challenge
+      -- :> Auth.HigherOrder
+      :> Post '[JSON] Challenge
   }
   deriving Generic

--- a/fission-web-api/library/Fission/Web/API/User/Challenge/Types.hs
+++ b/fission-web-api/library/Fission/Web/API/User/Challenge/Types.hs
@@ -4,7 +4,6 @@ import           Fission.Challenge.Types
 
 import           Fission.Web.API.Prelude
 
-import           Fission.User.Username.Types
 import qualified Fission.Web.API.Auth.Types  as Auth
 
 data Routes mode = Routes
@@ -12,8 +11,6 @@ data Routes mode = Routes
       mode
       :- "recover"
       :> Summary "Return challenge for account recovery"
-      --
-      :> Capture "Username" Username
       --
       :> Auth.HigherOrder
       :> Post '[JSON] Challenge

--- a/fission-web-api/library/Fission/Web/API/User/Types.hs
+++ b/fission-web-api/library/Fission/Web/API/User/Types.hs
@@ -6,6 +6,7 @@ import qualified Fission.Web.API.Relay.Types               as Relay
 import qualified Fission.Web.API.User.Create.Types         as Create
 import qualified Fission.Web.API.User.DID.Types            as DID
 import qualified Fission.Web.API.User.DataRoot.Types       as DataRoot
+import qualified Fission.Web.API.User.Challenge.Types      as Challenge
 import qualified Fission.Web.API.User.Email.Types          as Email
 import qualified Fission.Web.API.User.ExchangeKey.Types    as ExchangeKeys
 import qualified Fission.Web.API.User.Password.Reset.Types as Password
@@ -18,11 +19,12 @@ data RoutesV3 mode = RoutesV3
   deriving Generic
 
 data RoutesV2 mode = RoutesV2
-  { dataRoot     :: mode :- "data"   :> ToServantApi DataRoot.RoutesV2
-  , email        :: mode :- "email"  :> ToServantApi Email.Routes
-  , did          :: mode :- "did"    :> ToServantApi DID.RoutesV_
-  , whoAmI       :: mode :- "whoami" :> ToServantApi WhoAmI.Routes
-  , linkingRelay :: mode :- "link"   :> ToServantApi Relay.Routes
+  { dataRoot     :: mode :- "data"      :> ToServantApi DataRoot.RoutesV2
+  , challenge    :: mode :- "challenge" :> ToServantApi Challenge.Routes
+  , email        :: mode :- "email"     :> ToServantApi Email.Routes
+  , did          :: mode :- "did"       :> ToServantApi DID.RoutesV_
+  , whoAmI       :: mode :- "whoami"    :> ToServantApi WhoAmI.Routes
+  , linkingRelay :: mode :- "link"      :> ToServantApi Relay.Routes
   , create       :: mode :- Create.WithDID
   }
   deriving Generic

--- a/fission-web-client/library/Fission/Web/Client/V2.hs
+++ b/fission-web-client/library/Fission/Web/Client/V2.hs
@@ -17,6 +17,8 @@ module Fission.Web.Client.V2
   , setDIDViaUCAN
   , setDIDViaChallenge
   --
+  , recoverChallenge
+  --
   , verifyViaEmail
   , resendVerificationEmail
   , recoverViaEmail
@@ -36,6 +38,7 @@ import qualified Fission.Web.API.Types                            as Fission
 
 import qualified Fission.Web.API.User.DID.Types                   as User.DID
 import qualified Fission.Web.API.User.DataRoot.Types              as User.DataRoot
+import qualified Fission.Web.API.User.Challenge.Types             as User.Challenge
 import qualified Fission.Web.API.User.Email.Types                 as User.Email
 import qualified Fission.Web.API.User.Types                       as User
 import qualified Fission.Web.API.User.WhoAmI.Types                as User.WhoAmI
@@ -81,6 +84,11 @@ Fission.Routes
                       User.DID.RoutesV_
                         { setAuthenticated = setDIDViaUCAN
                         , setViaChallenge  = setDIDViaChallenge
+                        }
+
+                  , challenge = fromServant @_ @(AsClientT ClientM) ->
+                      User.Challenge.Routes
+                        { recover = recoverChallenge
                         }
 
                   , email = fromServant @_ @(AsClientT ClientM) ->

--- a/fission-web-client/library/Fission/Web/Client/V2.hs
+++ b/fission-web-client/library/Fission/Web/Client/V2.hs
@@ -17,7 +17,7 @@ module Fission.Web.Client.V2
   , setDIDViaUCAN
   , setDIDViaChallenge
   --
-  , recoverChallenge
+  , recoverViaChallenge
   --
   , verifyViaEmail
   , resendVerificationEmail
@@ -88,7 +88,7 @@ Fission.Routes
 
                   , challenge = fromServant @_ @(AsClientT ClientM) ->
                       User.Challenge.Routes
-                        { recover = recoverChallenge
+                        { recover = recoverViaChallenge
                         }
 
                   , email = fromServant @_ @(AsClientT ClientM) ->

--- a/fission-web-server/library/Fission/Web/Server/Handler/User.hs
+++ b/fission-web-server/library/Fission/Web/Server/Handler/User.hs
@@ -25,6 +25,7 @@ import qualified Fission.Web.Server.Handler.Relay               as Relay
 import qualified Fission.Web.Server.Handler.User.Create         as Create
 import qualified Fission.Web.Server.Handler.User.DID            as DID
 import qualified Fission.Web.Server.Handler.User.DataRoot       as DataRoot
+import qualified Fission.Web.Server.Handler.User.Challenge      as Challenge
 import qualified Fission.Web.Server.Handler.User.Email          as Email
 import qualified Fission.Web.Server.Handler.User.ExchangeKey    as ExchangeKey
 import qualified Fission.Web.Server.Handler.User.Password.Reset as Password.Reset
@@ -69,6 +70,7 @@ handlerV2 =
   User.RoutesV2
     { create       = Create.withDID
     , whoAmI       = genericServerT WhoAmI.handler
+    , challenge    = genericServerT Challenge.handler
     , email        = genericServerT Email.handler
     , did          = genericServerT DID.handlerV_
     , linkingRelay = genericServerT Relay.handler

--- a/fission-web-server/library/Fission/Web/Server/Handler/User/Challenge.hs
+++ b/fission-web-server/library/Fission/Web/Server/Handler/User/Challenge.hs
@@ -13,7 +13,6 @@ import qualified Fission.Web.Server.Challenge.Verifier.Class        as Challenge
 import qualified Fission.Web.Server.Error                           as Web.Err
 import           Fission.Web.Server.Models
 import qualified Fission.Web.Server.RecoveryChallenge.Creator.Class as RecoveryChallenge
-import           Fission.Web.Server.Redirect
 import           Fission.Web.Server.User.Retriever.Class            as User
 
 handler ::
@@ -28,8 +27,8 @@ handler ::
   => Challenge.Routes (AsServerT m)
 handler = Challenge.Routes {..}
   where
-    recover username = do
-      Entity userId User { } <- Web.Err.ensureMaybe couldntFindUser =<< getByUsername username
+    recover Authorization { about = Entity userId User { userUsername = username } } = do
+      Entity _ User { } <- Web.Err.ensureMaybe couldntFindUser =<< getByUsername username
       now       <- currentTime
       challenge <- RecoveryChallenge.create userId now
       return challenge

--- a/fission-web-server/library/Fission/Web/Server/Handler/User/Challenge.hs
+++ b/fission-web-server/library/Fission/Web/Server/Handler/User/Challenge.hs
@@ -8,17 +8,13 @@ import           Fission.Prelude
 import qualified Fission.Web.API.User.Challenge.Types               as Challenge
 
 import           Fission.Web.Server.Authorization.Types
-import qualified Fission.Web.Server.Challenge.Retriever.Class       as Challenge
-import qualified Fission.Web.Server.Challenge.Verifier.Class        as Challenge
 import qualified Fission.Web.Server.Error                           as Web.Err
 import           Fission.Web.Server.Models
 import qualified Fission.Web.Server.RecoveryChallenge.Creator.Class as RecoveryChallenge
 import           Fission.Web.Server.User.Retriever.Class            as User
 
 handler ::
-  ( Challenge.Retriever       m
-  , Challenge.Verifier        m
-  , RecoveryChallenge.Creator m
+  ( RecoveryChallenge.Creator m
   , User.Retriever            m
   , MonadThrow                m
   , MonadLogger               m
@@ -27,7 +23,7 @@ handler ::
   => Challenge.Routes (AsServerT m)
 handler = Challenge.Routes {..}
   where
-    recover Authorization { about = Entity userId User { userUsername = username } } = do
+    recover username Authorization { about = Entity userId _ } = do
       Entity _ User { } <- Web.Err.ensureMaybe couldntFindUser =<< getByUsername username
       now       <- currentTime
       challenge <- RecoveryChallenge.create userId now

--- a/fission-web-server/library/Fission/Web/Server/Handler/User/Challenge.hs
+++ b/fission-web-server/library/Fission/Web/Server/Handler/User/Challenge.hs
@@ -16,9 +16,6 @@ import qualified Fission.Web.Server.RecoveryChallenge.Creator.Class as RecoveryC
 import           Fission.Web.Server.Redirect
 import           Fission.Web.Server.User.Retriever.Class            as User
 
-import           Fission.Web.Server.Email.Types
-import           Fission.Web.Server.Email.Types
-
 handler ::
   ( Challenge.Retriever       m
   , Challenge.Verifier        m
@@ -26,23 +23,17 @@ handler ::
   , User.Retriever            m
   , MonadThrow                m
   , MonadLogger               m
-  -- , MonadEmail                m
   , MonadTime                 m
   )
   => Challenge.Routes (AsServerT m)
 handler = Challenge.Routes {..}
   where
     recover username = do
-      Entity userId User { userEmail } <- Web.Err.ensureMaybe couldntFindUser =<< getByUsername username
-      email <- Web.Err.ensureMaybe noAssociatedEmail userEmail
+      Entity userId User { } <- Web.Err.ensureMaybe couldntFindUser =<< getByUsername username
       now       <- currentTime
       challenge <- RecoveryChallenge.create userId now
-      return NoContent
-      -- return challenge
+      return challenge
 
       where
         couldntFindUser =
           err422 { errBody = "Couldn't find a user with this username" }
-
-        noAssociatedEmail =
-          err422 { errBody = "There is no email associated with the user" }

--- a/fission-web-server/library/Fission/Web/Server/Handler/User/Challenge.hs
+++ b/fission-web-server/library/Fission/Web/Server/Handler/User/Challenge.hs
@@ -1,0 +1,48 @@
+module Fission.Web.Server.Handler.User.Challenge (handler) where
+
+import           Servant
+import           Servant.Server.Generic
+
+import           Fission.Prelude
+
+import qualified Fission.Web.API.User.Challenge.Types               as Challenge
+
+import           Fission.Web.Server.Authorization.Types
+import qualified Fission.Web.Server.Challenge.Retriever.Class       as Challenge
+import qualified Fission.Web.Server.Challenge.Verifier.Class        as Challenge
+import qualified Fission.Web.Server.Error                           as Web.Err
+import           Fission.Web.Server.Models
+import qualified Fission.Web.Server.RecoveryChallenge.Creator.Class as RecoveryChallenge
+import           Fission.Web.Server.Redirect
+import           Fission.Web.Server.User.Retriever.Class            as User
+
+import           Fission.Web.Server.Email.Types
+import           Fission.Web.Server.Email.Types
+
+handler ::
+  ( Challenge.Retriever       m
+  , Challenge.Verifier        m
+  , RecoveryChallenge.Creator m
+  , User.Retriever            m
+  , MonadThrow                m
+  , MonadLogger               m
+  -- , MonadEmail                m
+  , MonadTime                 m
+  )
+  => Challenge.Routes (AsServerT m)
+handler = Challenge.Routes {..}
+  where
+    recover username = do
+      Entity userId User { userEmail } <- Web.Err.ensureMaybe couldntFindUser =<< getByUsername username
+      email <- Web.Err.ensureMaybe noAssociatedEmail userEmail
+      now       <- currentTime
+      challenge <- RecoveryChallenge.create userId now
+      return NoContent
+      -- return challenge
+
+      where
+        couldntFindUser =
+          err422 { errBody = "Couldn't find a user with this username" }
+
+        noAssociatedEmail =
+          err422 { errBody = "There is no email associated with the user" }

--- a/fission-web-server/package.yaml
+++ b/fission-web-server/package.yaml
@@ -15,7 +15,7 @@ maintainer:
   - james@fission.codes
   - brian@fission.codes
   - philipp@fission.codes
-copyright: © 2021 Fission Internet Software Services for Open Networks Inc.
+copyright: © 2023 Fission Internet Software Services for Open Networks Inc.
 license: AGPL-3.0-or-later
 license-file: LICENSE
 github: fission-suite/fission

--- a/fission-web-server/package.yaml
+++ b/fission-web-server/package.yaml
@@ -1,5 +1,5 @@
 name: fission-web-server
-version: "2.21.0.0"
+version: "2.21.0.1"
 category: API
 author:
   - Brooklyn Zelenka


### PR DESCRIPTION
## Summary

This PR fixes/implements the following **bugs/features**

* [x] `user/challenge/recover` endpoint to return a `challenge` directly from the API rather than sending an email to the user that has the `challenge` appended to the dashboard link

We need an endpoint that returns a `challenge` directly so the `rs-email-service` can call `/v2/api/user/did/{Username}/{Challenge}` on behalf of user to recover their account.

## Test plan (required)

We will deploy this branch to staging to allow for easier testing before it's merged

Create a new user and call `/v2/api/user/challenge/recover/{Username}` with a valid UCAN as the bearer token, expect a `challenge` to be returned

## After Merge
* [ ] Does this change invalidate any docs or tutorials? _If so ensure the changes needed are either made or recorded_
* [x] Does this change require a release to be made? Is so please create and deploy the release
